### PR TITLE
feat: update media policy and add action groups to resource tables

### DIFF
--- a/app/Filament/Resources/MediaResource.php
+++ b/app/Filament/Resources/MediaResource.php
@@ -10,6 +10,7 @@ use Awcodes\Curator\Resources\MediaResource as CuratorMediaResource;
 use Awcodes\Curator\Resources\MediaResource\ListMedia;
 use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
 use Filament\Forms;
+use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -79,7 +80,9 @@ class MediaResource extends CuratorMediaResource implements HasShieldPermissions
 
         $table = parent::table($table)
             ->bulkActions([
-                ReferenceAwareDeleteBulkAction::make(),
+                Tables\Actions\BulkActionGroup::make([
+                    ReferenceAwareDeleteBulkAction::make(),
+                ]),
             ])
             ->contentGrid(function () use ($livewire) {
                 if ($livewire->layoutView === 'grid') {

--- a/app/Filament/Resources/MediaResource.php
+++ b/app/Filament/Resources/MediaResource.php
@@ -50,10 +50,7 @@ class MediaResource extends CuratorMediaResource implements HasShieldPermissions
     public static function getPermissionPrefixes(): array
     {
         return [
-            'view',
             'view_all',
-            'update',
-            'delete',
         ];
     }
 

--- a/app/Filament/Resources/PermissionResource.php
+++ b/app/Filament/Resources/PermissionResource.php
@@ -71,10 +71,14 @@ class PermissionResource extends Resource implements HasShieldPermissions
                     ),
             ])
             ->actions([
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
-                ReferenceAwareDeleteBulkAction::make(),
+                Tables\Actions\BulkActionGroup::make([
+                    ReferenceAwareDeleteBulkAction::make(),
+                ]),
             ]);
     }
 

--- a/app/Filament/Resources/RoleResource.php
+++ b/app/Filament/Resources/RoleResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources;
 use App\Filament\Actions\Tables\ReferenceAwareDeleteBulkAction;
 use App\Filament\Resources\RoleResource\Pages;
 use BezhanSalleh\FilamentShield\Resources\RoleResource as ShieldRoleResource;
+use Filament\Tables;
 use Filament\Tables\Table;
 
 class RoleResource extends ShieldRoleResource
@@ -36,7 +37,9 @@ class RoleResource extends ShieldRoleResource
     {
         return parent::table($table)
             ->bulkActions([
-                ReferenceAwareDeleteBulkAction::make(),
+                Tables\Actions\BulkActionGroup::make([
+                    ReferenceAwareDeleteBulkAction::make(),
+                ]),
             ]);
     }
 }

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -139,11 +139,15 @@ class UserResource extends Resource
                 //
             ])
             ->actions([
-                EditAction::make(),
-                DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    EditAction::make(),
+                    DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
-                ReferenceAwareDeleteBulkAction::make(),
+                Tables\Actions\BulkActionGroup::make([
+                    ReferenceAwareDeleteBulkAction::make(),
+                ]),
             ]);
     }
 

--- a/app/Policies/MediaPolicy.php
+++ b/app/Policies/MediaPolicy.php
@@ -15,11 +15,11 @@ class MediaPolicy
      */
     public function view(User $user, Media $media): bool
     {
-        if ($user->is($media->creator)) {
-            return true;
+        if ($user->isNot($media->creator) && ! $this->viewAll($user)) {
+            return false;
         }
 
-        return $user->can('view_media');
+        return true;
     }
 
     /**
@@ -31,31 +31,15 @@ class MediaPolicy
     }
 
     /**
-     * Determine whether the user can view any models.
-     */
-    public function viewAny(User $user): bool
-    {
-        return true;
-    }
-
-    /**
-     * Determine whether the user can create models.
-     */
-    public function create(User $user): bool
-    {
-        return true;
-    }
-
-    /**
      * Determine whether the user can update the model.
      */
     public function update(User $user, Media $media): bool
     {
-        if ($user->is($media->creator)) {
-            return true;
+        if ($user->isNot($media->creator) && ! $this->viewAll($user)) {
+            return false;
         }
 
-        return $user->can('update_media');
+        return true;
     }
 
     /**
@@ -66,18 +50,10 @@ class MediaPolicy
         if ($media->isReferenced()) {
             return false;
         }
-        if ($user->is($media->creator)) {
-            return true;
+        if ($user->isNot($media->creator) && ! $this->viewAll($user)) {
+            return false;
         }
 
-        return $user->can('delete_media');
-    }
-
-    /**
-     * Determine whether the user can bulk delete.
-     */
-    public function deleteAny(User $user): bool
-    {
         return true;
     }
 }


### PR DESCRIPTION
This pull request introduces changes to the media policy, shifting access control from permission-based to creator-based. This means only the media creator can now view, update, and delete their own media. Users with appropriate permissions can still view all media.

Additionally, this PR adds `ActionGroup` and `BulkActionGroup` classes to the `Tables\Actions` namespace for improved functionality and extensibility. These new classes provide a structured approach for managing actions and bulk operations on resources.