### PR TITLE
fix: add name attributes to form inputs and form attribute tests for auth pages

### DIFF
--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -47,15 +47,18 @@ class Login extends Component implements HasForms
                             ->autofocus()
                             ->autocomplete('email')
                             ->default(old('email'))
-                            ->email(),
+                            ->email()
+                            ->extraInputAttributes(['name' => 'email']),
                         TextInput::make('password')
                             ->label(__('Password'))
                             ->required()
                             ->password()
                             ->revealable()
-                            ->hint(Route::has('password.request') ? new HtmlString(Blade::render('<x-filament::link wire:navigate href="{{ route(\'password.request\') }}" tabindex="3"> {{ __(\'filament-panels::pages/auth/login.actions.request_password_reset.label\') }}</x-filament::link>')) : null),
+                            ->hint(Route::has('password.request') ? new HtmlString(Blade::render('<x-filament::link wire:navigate href="{{ route(\'password.request\') }}" tabindex="3"> {{ __(\'filament-panels::pages/auth/login.actions.request_password_reset.label\') }}</x-filament::link>')) : null)
+                            ->extraInputAttributes(['name' => 'password']),
                         Checkbox::make('remember')
-                            ->label(__('Remember me')),
+                            ->label(__('Remember me'))
+                            ->extraInputAttributes(['name' => 'remember']),
                     ])
                     ->footerActions(array_filter([
                         Action::make('login')

--- a/app/Livewire/Auth/ResetPassword.php
+++ b/app/Livewire/Auth/ResetPassword.php
@@ -41,12 +41,14 @@ class ResetPassword extends Component implements HasForms
                 Section::make('request-password')
                     ->heading(__('filament-panels::pages/auth/password-reset/reset-password.heading'))
                     ->schema([
-                        Hidden::make('token'),
+                        Hidden::make('token')
+                            ->extraAttributes(['name' => 'token']),
                         TextInput::make('email')
                             ->label(__('filament-panels::pages/auth/password-reset/reset-password.form.email.label'))
                             ->readOnly()
                             ->autofocus()
-                            ->autocomplete('username'),
+                            ->autocomplete('username')
+                            ->extraInputAttributes(['name' => 'email']),
                         TextInput::make('password')
                             ->label(__('filament-panels::pages/auth/password-reset/reset-password.form.password.label'))
                             ->password()
@@ -54,13 +56,14 @@ class ResetPassword extends Component implements HasForms
                             ->required()
                             ->rule(Password::default())
                             ->same('passwordConfirmation')
-                            ->validationAttribute(__('filament-panels::pages/auth/password-reset/reset-password.form.password.validation_attribute')),
+                            ->validationAttribute(__('filament-panels::pages/auth/password-reset/reset-password.form.password.validation_attribute'))->extraInputAttributes(['name' => 'password']),
                         TextInput::make('passwordConfirmation')
                             ->label(__('filament-panels::pages/auth/password-reset/reset-password.form.password_confirmation.label'))
                             ->password()
                             ->revealable()
                             ->required()
-                            ->dehydrated(false),
+                            ->dehydrated(false)
+                            ->extraInputAttributes(['name' => 'password_confirmation']),
                     ])
                     ->footerActions([
                         Action::make('resetPassword')

--- a/tests/Feature/Livewire/Auth/ConfirmPasswordTest.php
+++ b/tests/Feature/Livewire/Auth/ConfirmPasswordTest.php
@@ -15,6 +15,14 @@ class ConfirmPasswordTest extends TestCase
         $component = Livewire::test(ConfirmPassword::class);
         $component->assertStatus(200);
     }
+    
+    public function test_confirm_password_form_has_proper_attributes(): void
+    {
+        $testable = Livewire::test(ConfirmPassword::class);
+        $testable->assertFormExists();
+        $testable->assertFormFieldExists('password');
+        $testable->assertSeeHtml('name="password"');
+    }
 
     public function test_confirm_password_form_validation(): void
     {

--- a/tests/Feature/Livewire/Auth/ForgotPasswordTest.php
+++ b/tests/Feature/Livewire/Auth/ForgotPasswordTest.php
@@ -21,6 +21,14 @@ class ForgotPasswordTest extends TestCase
         $testable->assertStatus(200);
     }
 
+    public function test_forgot_password_form_has_proper_attributes(): void
+    {
+        $testable = Livewire::test(ForgotPassword::class);
+        $testable->assertFormExists();
+        $testable->assertFormFieldExists('email');
+        $testable->assertSeeHtml('name="email"');
+    }
+
     public function test_email_is_required(): void
     {
         /** @var Testable */

--- a/tests/Feature/Livewire/Auth/LoginTest.php
+++ b/tests/Feature/Livewire/Auth/LoginTest.php
@@ -26,8 +26,11 @@ class LoginTest extends TestCase
         $testable = Livewire::test(Login::class);
         $testable->assertFormExists();
         $testable->assertFormFieldExists('email');
+        $testable->assertSeeHtml('name="email"');
         $testable->assertFormFieldExists('password');
+        $testable->assertSeeHtml('name="password"');
         $testable->assertFormFieldExists('remember');
+        $testable->assertSeeHtml('name="remember"');
     }
 
     public function test_user_can_login_with_valid_credentials(): void

--- a/tests/Feature/Livewire/Auth/RegisterTest.php
+++ b/tests/Feature/Livewire/Auth/RegisterTest.php
@@ -19,6 +19,22 @@ class RegisterTest extends TestCase
             ->assertStatus(200);
     }
 
+    public function test_register_form_has_proper_attributes(): void
+    {
+        $testable = Livewire::test(Register::class);
+        $testable->assertFormExists();
+        $testable->assertFormFieldExists('name');
+        $testable->assertSeeHtml('name="name"');
+        $testable->assertFormFieldExists('email');
+        $testable->assertSeeHtml('name="email"');
+        $testable->assertFormFieldExists('password');
+        $testable->assertSeeHtml('name="password"');
+        $testable->assertFormFieldExists('passwordConfirmation');
+        $testable->assertSeeHtml('name="password_confirmation"');
+        $testable->assertFormFieldExists('terms');
+        $testable->assertSeeHtml('name="terms"');
+    }
+
     public function test_registration_screen_can_be_rendered(): void
     {
         if (! Features::enabled(Features::registration())) {

--- a/tests/Feature/Livewire/Auth/ResetPasswordTest.php
+++ b/tests/Feature/Livewire/Auth/ResetPasswordTest.php
@@ -21,6 +21,20 @@ class ResetPasswordTest extends TestCase
             ->assertStatus(200);
     }
 
+    public function test_reset_password_form_has_proper_attributes(): void
+    {
+        $testable = Livewire::test(ResetPassword::class);
+        $testable->assertFormExists();
+        $testable->assertFormFieldExists('token');
+        $testable->assertSeeHtml('name="token"');
+        $testable->assertFormFieldExists('email');
+        $testable->assertSeeHtml('name="email"');
+        $testable->assertFormFieldExists('password');
+        $testable->assertSeeHtml('name="password"');
+        $testable->assertFormFieldExists('passwordConfirmation');
+        $testable->assertSeeHtml('name="password_confirmation"');
+    }
+
     public function test_reset_password_link_screen_can_be_rendered(): void
     {
         if (! Features::enabled(Features::resetPasswords())) {

--- a/tests/Feature/Livewire/Auth/TwoFactorChallengeTest.php
+++ b/tests/Feature/Livewire/Auth/TwoFactorChallengeTest.php
@@ -25,6 +25,17 @@ class TwoFactorChallengeTest extends TestCase
             ->assertStatus(200);
     }
 
+    public function test_two_factor_challenge_form_has_proper_attributes(): void
+    {
+        $testable = Livewire::test(TwoFactorChallenge::class);
+        $testable->assertFormExists();
+        $testable->assertFormFieldExists('code');
+        $testable->assertSeeHtml('name="code"');
+
+        $testable->set('showRecovery', true);
+        $testable->assertSeeHtml('name="recovery_code"');
+    }
+
     public function test_component_renders_authentication_code_form_by_default(): void
     {
         /** @var Testable */


### PR DESCRIPTION
This pull request addresses a missing `name` attribute issue in the authentication forms and adds comprehensive form attribute tests to the Livewire components.

The commit adds `name` attributes to the input fields in the login and reset password forms to ensure proper form submission and handling.

Additionally, it introduces tests to verify that all form fields in the authentication Livewire components have the correct attributes, specifically the `name` attribute. This enhances the robustness and reliability of the tests by validating the correct HTML structure of the forms in the following components: ConfirmPassword, ForgotPassword, Login, Register, ResetPassword, and TwoFactorChallenge.