### PR TITLE
feat: improve Android client support

### DIFF
--- a/app/Http/Middleware/SetDeviceFromHeader.php
+++ b/app/Http/Middleware/SetDeviceFromHeader.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Utils\Device;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetDeviceFromHeader
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $userAgent = $request->header('User-Agent');
+        if ($userAgent && str_contains($userAgent, 'wv')) {
+            Device::setIsAndroid(true);
+        }
+
+        $requestedWithHeader = $request->header('x-requested-with');
+        if ($requestedWithHeader) {
+            Device::setRequestedWith($requestedWithHeader);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Utils/Device.php
+++ b/app/Utils/Device.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Utils;
+
+class Device
+{
+    public static bool $isAndroid = false;
+
+    public static ?string $requestedWith = null;
+
+    public static function setIsAndroid(bool $value): void
+    {
+        static::$isAndroid = $value;
+    }
+
+    public static function setRequestedWith(?string $value): void
+    {
+        static::$requestedWith = $value;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\EnsureJsonRequest;
+use App\Http\Middleware\SetDeviceFromHeader;
 use App\Http\Middleware\SetLocaleFromHeader;
 use App\Http\Middleware\SetLocaleFromQueryAndSession;
 use App\Http\Middleware\VerifyApiArtisan;
@@ -19,6 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->append(ProtectAgainstSpam::class);
+        $middleware->append(SetDeviceFromHeader::class);
         $middleware->append(SetLocaleFromHeader::class);
         $middleware->web(append: [SetLocaleFromQueryAndSession::class]);
         $middleware->statefulApi();

--- a/resources/ts/android.d.ts
+++ b/resources/ts/android.d.ts
@@ -1,4 +1,6 @@
 export interface Android {
+    getPackageName?: () => string | null;
+    getVersionCode?: () => number | null;
     navigate?: () => void;
     navigated?: () => void;
     switchLanguage?: (lang: string) => void;

--- a/resources/views/components/navigation-menu/language-switcher.blade.php
+++ b/resources/views/components/navigation-menu/language-switcher.blade.php
@@ -13,8 +13,10 @@
             <x-filament::icon icon="heroicon-m-chevron-down" color="gray" class="size-3" />
         </button>
     </x-slot>
-    <x-filament::dropdown.list class="space-y-1">
-        <x-navigation-menu.language-switcher-item locale="id" languageName="Bahasa Indonesia" :currentLocale="$currentLocale" />
-        <x-navigation-menu.language-switcher-item locale="en" languageName="English" :currentLocale="$currentLocale" />
+    <x-filament::dropdown.list class="space-y-1" x-data="languageSwitcher" x-init="switchLanguage('{{ $currentLocale }}')">
+        <x-navigation-menu.language-switcher-item locale="id" languageName="Bahasa Indonesia" :currentLocale="$currentLocale"
+            x-on:click="switchLanguage('id')" />
+        <x-navigation-menu.language-switcher-item locale="en" languageName="English" :currentLocale="$currentLocale"
+            x-on:click="switchLanguage('en')" />
     </x-filament::dropdown.list>
 </x-filament::dropdown>


### PR DESCRIPTION
This pull request focuses on improving Android client support with the following changes:

- Reinstates Alpine.js for the language switcher, ensuring proper language switching functionality for Android users. This resolves an issue where language switching was broken for Android clients due to a missing Alpine.js implementation.
- Introduces `getPackageName` and `getVersionCode` functions to the Android interface. This allows the Android client to expose native Android application information (package name and version code) to the web application, enabling platform-specific logic and potentially improved debugging or feature management.
- Adds `SetDeviceFromHeader` middleware to specifically detect requests originating from the Android app. This middleware identifies Android devices and the 'x-requested-with' header, making this information accessible throughout the application. This allows for tailored responses or behaviors specifically for the Android client.

These changes collectively improve the integration and support for the Android client by fixing UI interactions, providing access to native Android information, and enabling device-specific handling within the application.