### PR TITLE
refactor: remove phpstan ignore and correct throttle limit in two factor challenge test

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -55,7 +55,7 @@ class AppServiceProvider extends ServiceProvider
         if (! $locales) {
             throw new Exception('Supported locales are null.');
         }
-        // @phpstan-ignore-next-line
+
         FilamentTranslateField::defaultLocales($locales);
     }
 }

--- a/tests/Feature/Http/Controllers/Api/V1/TwoFactorChallengeControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V1/TwoFactorChallengeControllerTest.php
@@ -193,6 +193,7 @@ class TwoFactorChallengeControllerTest extends TestCase
         $limit = config('api.limit_per_minute', 5);
 
         $loginId = $this->getTwoFactorAuthenticationLoginId();
+        $limit--;
 
         foreach (range(0, $limit) as $i) {
             $response = $this->postJson(route('api.v1.two-factor-challenge'), [


### PR DESCRIPTION
This pull request refactors the codebase by removing an unnecessary `@phpstan-ignore-next-line` annotation and correcting a throttle limit error in a test.

The `@phpstan-ignore-next-line` annotation was removed from the `AppServiceProvider.php` file because it was no longer needed. The code now correctly handles the case where `$locales` is null, making the annotation redundant.

The throttle limit in the `test_two_factor_challenge_endpoint_is_throttled` test was off by one, causing intermittent test failures. This commit decrements the limit by one before the loop to ensure the number of requests sent stays within the throttle limit, thus correcting the test.