### PR TITLE
feat: add option to edit commit and PR messages in editor

### DIFF
--- a/app/Console/Commands/Llm/Commit.php
+++ b/app/Console/Commands/Llm/Commit.php
@@ -3,6 +3,8 @@
 namespace App\Console\Commands\Llm;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Prism\Prism\Prism;
 use Symfony\Component\Process\Process;
 
@@ -13,7 +15,7 @@ class Commit extends Command
      *
      * @var string
      */
-    protected $signature = 'llm:commit';
+    protected $signature = 'llm:commit {--editor= : Specify the editor to use (e.g., nano, vim, code --wait)}';
 
     /**
      * The console command description.
@@ -59,13 +61,13 @@ class Commit extends Command
 
         The `commit message` should be strictly in this format:
 
-        ```
+        <format>
         type: brief description
 
         body of the commit message
-        ```
+        </format>
 
-        The `type` should be one of fix, feat, docs, style, refactor, perf, test, build, ci, chore, or revert. Please identify the `type` from the diff, create the `brief description`, and include a `body of the commit message` that describes the changes, reasoning, or any other relevant information. The `brief description` must start the sentence with a lowercase letter. The `body of the commit message` should be wrapped in paragraphs using Markdown format. Do not add explanations, only the `commit message`.
+        The `type` should be one of fix, feat, docs, style, refactor, perf, test, build, ci, chore, or revert. Please identify the `type` from the diff, create the `brief description`, and include a `body of the commit message` that describes the changes, reasoning, or any other relevant information. The `brief description` must start the sentence with a lowercase letter. Do not add explanations, only the `commit message`.
         MARKDOWN;
 
         $prompt = strtr($template, [
@@ -87,13 +89,61 @@ class Commit extends Command
         $endTime = microtime(true);
         $elapsedTime = $endTime - $startTime;
 
+        $proposedMessage = trim($response->text);
+
         $this->newLine();
         $this->info('Proposed commit message:');
         $this->info('------------------------');
-        $this->line(trim($response->text));
+        $this->line($proposedMessage);
         $this->info('------------------------');
+
         $this->info('Elapsed time: '.round($elapsedTime, 2).' seconds');
         $this->info("Prompt tokens: {$response->usage->promptTokens}");
         $this->info("Completion tokens: {$response->usage->completionTokens}");
+
+        /** @var ?string */
+        $editor = $this->option('editor');
+
+        if (! $editor) {
+            $editInEditor = $this->confirm('Do you want to open this message in an editor to make changes?');
+        } else {
+            $editInEditor = true;
+        }
+
+        if ($editInEditor) {
+            if (! $editor) {
+                // If no editor is found, ask the user
+                /** @var ?string */
+                $editor = $this->ask('Please enter the command for your preferred editor (e.g., nano, vim, code --wait):');
+            }
+
+            if ($editor) {
+                // Create a unique temporary file path for the commit message
+                $tempFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'llm_commit_'.Str::uuid()->toString().'.md';
+
+                // Write the proposed message to the temporary file
+                File::put($tempFilePath, $proposedMessage);
+
+                $this->info("Opening commit message in editor: '{$editor} {$tempFilePath}'");
+
+                // Construct the process command string, escaping the file path
+                $command = "{$editor} ".escapeshellarg($tempFilePath);
+
+                $process = Process::fromShellCommandline($command);
+                $process->setTimeout(null); // Allow indefinite editing time
+                $process->setTty(Process::isTtySupported()); // Enable TTY for interactive editors
+
+                try {
+                    $process->run(); // Execute the editor process
+                } catch (\Exception $e) {
+                    $this->error('Error during editor execution: '.$e->getMessage());
+                } finally {
+                    // Clean up the temporary file
+                    File::delete($tempFilePath);
+                }
+            } else {
+                $this->warn('No editor command provided. Skipping editor step.');
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature that allows users to edit both commit messages and pull request messages generated by the LLM in their preferred editor before finalizing them.

The following changes were implemented:

- Added an `--editor` option to both the commit and pull request commands. This option allows the user to specify which editor to use.
- If no editor is specified via the `--editor` flag, the user will be prompted to enter the command to open their preferred editor.
- The proposed message is written to a temporary file.
- The specified editor is opened with the temporary file.
- After the editor is closed, the temporary file is deleted.

This enhancement provides flexibility to refine the generated messages, ensuring they accurately reflect the changes and adhere to project conventions. This allows users to refine the message before submitting it, ensuring clarity and accuracy.