### PR TITLE
feat: enhance filament import/export functionalities

### DIFF
--- a/app/Filament/Exports/PageExporter.php
+++ b/app/Filament/Exports/PageExporter.php
@@ -26,7 +26,7 @@ class PageExporter extends Exporter
                 ->state(fn (Page $record) => $record->getTranslations('content'))
                 ->listAsJson(),
             ExportColumn::make('status')
-                ->formatStateUsing(fn (Status $state): string => $state->value),
+                ->formatStateUsing(fn (Status $state): string => static::formatStatus($state)),
             ExportColumn::make('created_at'),
             ExportColumn::make('updated_at'),
         ]);
@@ -41,5 +41,10 @@ class PageExporter extends Exporter
         }
 
         return $body;
+    }
+
+    public static function formatStatus(Status $state): string
+    {
+        return $state->value;
     }
 }

--- a/app/Filament/Exports/PageExporter.php
+++ b/app/Filament/Exports/PageExporter.php
@@ -17,7 +17,7 @@ class PageExporter extends Exporter
         return [
             ExportColumn::make('id')
                 ->label('ID'),
-            ExportColumn::make('creator.name'),
+            ExportColumn::make('creator_id'),
             ExportColumn::make('title'),
             ExportColumn::make('content'),
             ExportColumn::make('status')

--- a/app/Filament/Exports/PageExporter.php
+++ b/app/Filament/Exports/PageExporter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Exports;
+
+use App\Enums\Page\Status;
+use App\Models\Page;
+use Filament\Actions\Exports\ExportColumn;
+use Filament\Actions\Exports\Exporter;
+use Filament\Actions\Exports\Models\Export;
+
+class PageExporter extends Exporter
+{
+    protected static ?string $model = Page::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ExportColumn::make('id')
+                ->label('ID'),
+            ExportColumn::make('creator.name'),
+            ExportColumn::make('title'),
+            ExportColumn::make('content'),
+            ExportColumn::make('status')
+                ->formatStateUsing(fn (Status $state): string => $state->value),
+            ExportColumn::make('created_at'),
+            ExportColumn::make('updated_at'),
+        ];
+    }
+
+    public static function getCompletedNotificationBody(Export $export): string
+    {
+        $body = __('page.export_completed', ['successful_rows' => number_format($export->successful_rows)]);
+
+        if ($failedRowsCount = $export->getFailedRowsCount()) {
+            $body .= ' '.__('page.export_failed', ['failed_rows' => number_format($failedRowsCount)]);
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Exports/PageExporter.php
+++ b/app/Filament/Exports/PageExporter.php
@@ -7,6 +7,7 @@ use App\Models\Page;
 use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
+use Illuminate\Support\Facades\Gate;
 
 class PageExporter extends Exporter
 {
@@ -14,17 +15,21 @@ class PageExporter extends Exporter
 
     public static function getColumns(): array
     {
-        return [
+        return array_filter([
             ExportColumn::make('id')
                 ->label('ID'),
-            ExportColumn::make('creator_id'),
-            ExportColumn::make('title'),
-            ExportColumn::make('content'),
+            Gate::check('viewAll', Page::class) ? ExportColumn::make('creator_id') : null,
+            ExportColumn::make('title')
+                ->state(fn (Page $record) => $record->getTranslations('title'))
+                ->listAsJson(),
+            ExportColumn::make('content')
+                ->state(fn (Page $record) => $record->getTranslations('content'))
+                ->listAsJson(),
             ExportColumn::make('status')
                 ->formatStateUsing(fn (Status $state): string => $state->value),
             ExportColumn::make('created_at'),
             ExportColumn::make('updated_at'),
-        ];
+        ]);
     }
 
     public static function getCompletedNotificationBody(Export $export): string

--- a/app/Filament/Imports/PageImporter.php
+++ b/app/Filament/Imports/PageImporter.php
@@ -56,7 +56,7 @@ class PageImporter extends Importer
             // Page exists, check permissions to update
             if (Gate::forUser($importingUser)->check('viewAll', Page::class)) {
                 // User has permission to view all pages, update the page
-                $page->fill($this->data);
+                $page->fill(Arr::only($this->data, $page->getFillable()));
             } else {
                 // User doesn't have permission to view all pages, check if they own the page
                 if ($page->creator->is($importingUser)) {
@@ -65,7 +65,7 @@ class PageImporter extends Importer
                     // Prevent a user from changing the owner of their own page
                     $updateData = Arr::except($this->data, ['creator_id', 'id']);
 
-                    $page->fill($updateData);
+                    $page->fill(Arr::only($updateData, $page->getFillable()));
                 } else {
                     // User doesn't own the page and doesn't have viewAll permission, skip the row
                     return null;
@@ -100,8 +100,7 @@ class PageImporter extends Importer
             // All requirements are met, create a new page
             $page = new Page;
             $this->data['creator_id'] = $creatorId;
-            $fillableData = array_intersect_key($this->data, array_flip($page->getFillable()));
-            $page->fill($fillableData);
+            $page->fill(Arr::only($this->data, $page->getFillable()));
         }
 
         return $page;
@@ -131,10 +130,6 @@ class PageImporter extends Importer
 
             if (json_last_error() === JSON_ERROR_NONE) {
                 $data[$field] = $decoded;
-            } else {
-                // Option 1: Throw an exception to fail the row
-                throw new \Exception("Invalid JSON in '{$field}' field.");
-                // Option 2: Do nothing, let validation handle the non-array data
             }
         }
 

--- a/app/Filament/Imports/PageImporter.php
+++ b/app/Filament/Imports/PageImporter.php
@@ -111,7 +111,7 @@ class PageImporter extends Importer
     {
         return [
             // Allow nullable for new records
-            'id' => ['nullable', Rule::exists('pages', 'id')],
+            'id' => ['nullable', 'string'],
 
             // Add validation for creator_id if the column exists
             'creator_id' => ['required', Rule::exists('users', 'id')],
@@ -149,6 +149,8 @@ class PageImporter extends Importer
 
             if (json_last_error() === JSON_ERROR_NONE) {
                 $data[$field] = $decoded;
+            } else {
+                throw new \Exception("Failed to decode JSON for field: $field. Error: ".json_last_error_msg());
             }
         }
 

--- a/app/Filament/Imports/PageImporter.php
+++ b/app/Filament/Imports/PageImporter.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Imports;
+
+use App\Models\Page;
+use Filament\Actions\Imports\ImportColumn;
+use Filament\Actions\Imports\Importer;
+use Filament\Actions\Imports\Models\Import;
+use Illuminate\Database\Eloquent\Model;
+
+class PageImporter extends Importer
+{
+    protected static ?string $model = Page::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ImportColumn::make('id')
+                ->label('ID'),
+            ImportColumn::make('creator_id'),
+            ImportColumn::make('title'),
+            ImportColumn::make('content'),
+            ImportColumn::make('status'),
+            ImportColumn::make('created_at'),
+            ImportColumn::make('updated_at'),
+        ];
+    }
+
+    public function resolveRecord(): ?Model
+    {
+        /** @var Model */
+        $model = app(static::getModel());
+        $keyName = $model->getKeyName();
+        $keyColumnName = $this->columnMap[$keyName] ?? $keyName;
+
+        /** @var ?Page */
+        $page = Page::find($this->data[$keyColumnName]);
+
+        if (! $page) {
+            $page = new Page;
+        }
+
+        return $page;
+    }
+
+    public static function getCompletedNotificationBody(Import $import): string
+    {
+        $body = '<strong>'.number_format($import->successful_rows).'</strong> '.str('row')->plural($import->successful_rows).' '.__('page.import_completed', ['successful_rows' => $import->successful_rows]);
+
+        if ($failedRows = $import->getFailedRowsCount()) {
+            $body .= ' <strong>'.number_format($failedRows).'</strong> '.str('row')->plural($failedRows).' '.__('page.import_failed', ['failed_rows' => $failedRows]);
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Imports/PageImporter.php
+++ b/app/Filament/Imports/PageImporter.php
@@ -11,6 +11,7 @@ use Filament\Actions\Imports\Models\Import;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
 
 class PageImporter extends Importer
 {
@@ -104,6 +105,24 @@ class PageImporter extends Importer
         }
 
         return $page;
+    }
+
+    public function getValidationRules(): array
+    {
+        return [
+            // Allow nullable for new records
+            'id' => ['nullable', Rule::exists('pages', 'id')],
+
+            // Add validation for creator_id if the column exists
+            'creator_id' => ['required', Rule::exists('users', 'id')],
+
+            // Title and content are handled by decodeTranslatableData,
+            // but you could add basic checks here if desired.
+            'title' => ['required', 'array'],
+            'content' => ['required', 'array'],
+
+            'status' => ['required', Rule::enum(Status::class)],
+        ];
     }
 
     public static function getCompletedNotificationBody(Import $import): string

--- a/app/Filament/Resources/ExportResource.php
+++ b/app/Filament/Resources/ExportResource.php
@@ -110,6 +110,20 @@ class ExportResource extends Resource implements HasShieldPermissions
             ])
             ->actions([
                 Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\Action::make('download_csv')
+                        ->label(__('export.download_name', ['name' => 'CSV']))
+                        ->icon('heroicon-o-document-arrow-down')
+                        ->url(fn (Export $record): string => route('filament.exports.download', ['export' => $record->id, 'format' => 'csv']))
+                        ->openUrlInNewTab()
+                        ->visible(fn (Export $record) => filled($record->file_name) && filled($record->file_disk)),
+                    Tables\Actions\Action::make('download_xlsx')
+                        ->label(__('export.download_name', ['name' => 'XLSX']))
+                        ->icon('heroicon-o-document-arrow-down')
+                        ->url(fn (Export $record): string => route('filament.exports.download', ['export' => $record->id, 'format' => 'xlsx']))
+                        ->openUrlInNewTab()
+                        ->visible(fn (Export $record) => filled($record->file_name) && filled($record->file_disk)),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/ExportResource.php
+++ b/app/Filament/Resources/ExportResource.php
@@ -40,7 +40,7 @@ class ExportResource extends Resource implements HasShieldPermissions
 
     public static function getNavigationGroup(): ?string
     {
-        return __('export.navigation_group');
+        return __('Data Management');
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/ExportResource.php
+++ b/app/Filament/Resources/ExportResource.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Actions\Tables\ReferenceAwareDeleteBulkAction;
+use App\Filament\Resources\ExportResource\Pages;
+use App\Models\Export;
+use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class ExportResource extends Resource implements HasShieldPermissions
+{
+    protected static ?string $model = Export::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-arrow-path-rounded-square';
+
+    public static function canViewAll(): bool
+    {
+        return static::can('viewAll');
+    }
+
+    /**
+     * @return Builder<Export>
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        /** @var Builder<Export> */
+        $query = parent::getEloquentQuery();
+
+        if (! static::canViewAll()) {
+            $query->where('creator_id', Auth::id());
+        }
+
+        return $query;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('export.navigation_group');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListExports::route('/'),
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getPermissionPrefixes(): array
+    {
+        return ['view_all'];
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('exporter')
+                    ->label(__('export.exporter'))
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('file_name')
+                    ->label(__('export.file_name'))
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('file_disk')
+                    ->label(__('export.file_disk'))
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('total_rows')
+                    ->label(__('export.total_rows'))
+                    ->numeric()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('processed_rows')
+                    ->label(__('export.processed_rows'))
+                    ->numeric()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('successful_rows')
+                    ->label(__('export.successful_rows'))
+                    ->numeric()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label(__('export.initiated_by'))
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('completed_at')
+                    ->label(__('export.completed_at'))
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->label(ucfirst(__('validation.attributes.created_at')))
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->label(ucfirst(__('validation.attributes.updated_at')))
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('creator.name')
+                    ->label(ucfirst(__('validation.attributes.creator')))
+                    ->searchable(),
+            ])
+            ->actions([
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    ReferenceAwareDeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/ExportResource.php
+++ b/app/Filament/Resources/ExportResource.php
@@ -32,7 +32,7 @@ class ExportResource extends Resource implements HasShieldPermissions
         $query = parent::getEloquentQuery();
 
         if (! static::canViewAll()) {
-            $query->where('creator_id', Auth::id());
+            $query->where('user_id', Auth::id());
         }
 
         return $query;
@@ -91,7 +91,8 @@ class ExportResource extends Resource implements HasShieldPermissions
                 Tables\Columns\TextColumn::make('user.name')
                     ->label(__('export.initiated_by'))
                     ->sortable()
-                    ->toggleable(isToggledHiddenByDefault: true),
+                    ->toggleable(isToggledHiddenByDefault: true)
+                    ->visible(static::canViewAll()),
                 Tables\Columns\TextColumn::make('completed_at')
                     ->label(__('export.completed_at'))
                     ->dateTime()
@@ -106,9 +107,6 @@ class ExportResource extends Resource implements HasShieldPermissions
                     ->label(ucfirst(__('validation.attributes.updated_at')))
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
-                Tables\Columns\TextColumn::make('creator.name')
-                    ->label(ucfirst(__('validation.attributes.creator')))
-                    ->searchable(),
             ])
             ->actions([
                 Tables\Actions\DeleteAction::make(),

--- a/app/Filament/Resources/ExportResource.php
+++ b/app/Filament/Resources/ExportResource.php
@@ -65,7 +65,14 @@ class ExportResource extends Resource implements HasShieldPermissions
                 Tables\Columns\TextColumn::make('exporter')
                     ->label(__('export.exporter'))
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->formatStateUsing(function (string $state): string {
+                        $exporterName = class_basename($state); // e.g., PageExporter
+                        $modelName = str_replace('Exporter', '', $exporterName); // e.g., Page
+                        $lowercasedModelName = strtolower($modelName); // e.g., page
+
+                        return trans_choice("{$lowercasedModelName}.resource.model_label", 1);
+                    }),
                 Tables\Columns\TextColumn::make('file_name')
                     ->label(__('export.file_name'))
                     ->searchable()

--- a/app/Filament/Resources/ExportResource/Pages/ListExports.php
+++ b/app/Filament/Resources/ExportResource/Pages/ListExports.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ExportResource\Pages;
+
+use App\Filament\Resources\ExportResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListExports extends ListRecords
+{
+    protected static string $resource = ExportResource::class;
+}

--- a/app/Filament/Resources/ImportResource.php
+++ b/app/Filament/Resources/ImportResource.php
@@ -62,6 +62,17 @@ class ImportResource extends Resource implements HasShieldPermissions
     {
         return $table
             ->columns([
+                TextColumn::make('importer')
+                    ->label(__('import.importer'))
+                    ->searchable()
+                    ->sortable()
+                    ->formatStateUsing(function (string $state): string {
+                        $importerName = class_basename($state); // e.g., PageImporter
+                        $modelName = str_replace('Importer', '', $importerName); // e.g., Page
+                        $lowercasedModelName = strtolower($modelName); // e.g., page
+
+                        return trans_choice("{$lowercasedModelName}.resource.model_label", 1);
+                    }),
                 TextColumn::make('file_name')
                     ->label(__('import.file_name'))
                     ->searchable()
@@ -71,10 +82,6 @@ class ImportResource extends Resource implements HasShieldPermissions
                     ->searchable()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
-                TextColumn::make('importer')
-                    ->label(__('import.importer'))
-                    ->searchable()
-                    ->sortable(),
                 TextColumn::make('total_rows')
                     ->label(__('import.total_rows'))
                     ->numeric()
@@ -91,7 +98,8 @@ class ImportResource extends Resource implements HasShieldPermissions
                     ->label(__('import.user'))
                     ->searchable()
                     ->sortable()
-                    ->visible(static::canViewAll()),
+                    ->visible(static::canViewAll())
+                    ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('completed_at')
                     ->label(__('import.completed_at'))
                     ->dateTime()

--- a/app/Filament/Resources/ImportResource.php
+++ b/app/Filament/Resources/ImportResource.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Actions\Tables\ReferenceAwareDeleteBulkAction;
+use App\Filament\Resources\ImportResource\Pages;
+use App\Models\Import;
+use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
+use Filament\Resources\Resource;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class ImportResource extends Resource implements HasShieldPermissions
+{
+    protected static ?string $model = Import::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-arrow-down-tray';
+
+    public static function canViewAll(): bool
+    {
+        return static::can('viewAll');
+    }
+
+    /**
+     * @return Builder<Import>
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        /** @var Builder<Import> */
+        $query = parent::getEloquentQuery();
+
+        if (! static::canViewAll()) {
+            $query->where('user_id', Auth::id());
+        }
+
+        return $query;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('Data Management');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListImports::route('/'),
+        ];
+    }
+
+    /** @return array<string> */
+    public static function getPermissionPrefixes(): array
+    {
+        return ['view_all'];
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('file_name')
+                    ->label(__('import.file_name'))
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('file_path')
+                    ->label(__('import.file_path'))
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('importer')
+                    ->label(__('import.importer'))
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('total_rows')
+                    ->label(__('import.total_rows'))
+                    ->numeric()
+                    ->sortable(),
+                TextColumn::make('processed_rows')
+                    ->label(__('import.processed_rows'))
+                    ->numeric()
+                    ->sortable(),
+                TextColumn::make('successful_rows')
+                    ->label(__('import.successful_rows'))
+                    ->numeric()
+                    ->sortable(),
+                TextColumn::make('user.name')
+                    ->label(__('import.user'))
+                    ->searchable()
+                    ->sortable()
+                    ->visible(static::canViewAll()),
+                TextColumn::make('completed_at')
+                    ->label(__('import.completed_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->label(ucfirst(__('validation.attributes.created_at')))
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->label(ucfirst(__('validation.attributes.updated_at')))
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->actions([
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    ReferenceAwareDeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/ImportResource/Pages/ListImports.php
+++ b/app/Filament/Resources/ImportResource/Pages/ListImports.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ImportResource\Pages;
+
+use App\Filament\Resources\ImportResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListImports extends ListRecords
+{
+    protected static string $resource = ImportResource::class;
+}

--- a/app/Filament/Resources/PageResource.php
+++ b/app/Filament/Resources/PageResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Concerns\HasLocales;
 use App\Enums\Page\Status;
+use App\Filament\Exports\PageExporter;
 use App\Filament\Resources\PageResource\Pages;
 use App\Filament\Resources\UserResource\Utils\Creator;
 use App\Models\Page;
@@ -14,6 +15,7 @@ use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Actions\ExportBulkAction;
 use Filament\Tables\Table;
 use FilamentTiptapEditor\TiptapEditor;
 use Illuminate\Database\Eloquent\Builder;
@@ -170,6 +172,8 @@ class PageResource extends Resource implements HasShieldPermissions
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DeleteBulkAction::make(),
+                    ExportBulkAction::make()
+                        ->exporter(PageExporter::class),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/PageResource/Pages/ListPages.php
+++ b/app/Filament/Resources/PageResource/Pages/ListPages.php
@@ -2,8 +2,10 @@
 
 namespace App\Filament\Resources\PageResource\Pages;
 
+use App\Filament\Imports\PageImporter;
 use App\Filament\Resources\PageResource;
 use Filament\Actions;
+use Filament\Actions\ImportAction;
 use Filament\Resources\Pages\ListRecords;
 
 class ListPages extends ListRecords
@@ -13,6 +15,8 @@ class ListPages extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            ImportAction::make()
+                ->importer(PageImporter::class),
             Actions\CreateAction::make(),
         ];
     }

--- a/app/Filament/Resources/PageResource/Pages/ListPages.php
+++ b/app/Filament/Resources/PageResource/Pages/ListPages.php
@@ -16,6 +16,7 @@ class ListPages extends ListRecords
     {
         return [
             ImportAction::make()
+                ->label(__('Import :name', ['name' => trans_choice('page.resource.model_label', 2)]))
                 ->importer(PageImporter::class),
             Actions\CreateAction::make(),
         ];

--- a/app/Models/Export.php
+++ b/app/Models/Export.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use Filament\Actions\Exports\Models\Export as FilamentExport;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 
+/**
+ * @property-read User $user
+ */
 class Export extends FilamentExport
 {
     use HasUlids;

--- a/app/Models/Export.php
+++ b/app/Models/Export.php
@@ -4,12 +4,29 @@ namespace App\Models;
 
 use Filament\Actions\Exports\Models\Export as FilamentExport;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Carbon;
 
 /**
+ * @property string $user_id
+ * @property ?Carbon $completed_at
+ * @property string $file_disk
+ * @property string|null $file_name
+ * @property string $exporter
+ * @property int $processed_rows
+ * @property int $total_rows
+ * @property int $successful_rows
+ * @property ?Carbon $created_at
+ * @property ?Carbon $updated_at
  * @property-read User $user
+ *
+ * @method static \Database\Factories\ExportFactory factory(...$parameters)
  */
 class Export extends FilamentExport
 {
+    /** @use HasFactory<\Database\Factories\ExportFactory> */
+    use HasFactory;
+
     use HasUlids;
 
     protected static function booted(): void

--- a/app/Models/Export.php
+++ b/app/Models/Export.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Filament\Actions\Exports\Models\Export as FilamentExport;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+
+class Export extends FilamentExport
+{
+    use HasUlids;
+}

--- a/app/Models/Export.php
+++ b/app/Models/Export.php
@@ -8,4 +8,18 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 class Export extends FilamentExport
 {
     use HasUlids;
+
+    protected static function booted(): void
+    {
+        parent::booted();
+
+        static::deleted(function (Export $export) {
+            $disk = $export->getFileDisk();
+            $directory = $export->getFileDirectory();
+
+            if ($disk->exists($directory)) {
+                $disk->deleteDirectory($directory);
+            }
+        });
+    }
 }

--- a/app/Models/FailedImportRow.php
+++ b/app/Models/FailedImportRow.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Filament\Actions\Imports\Models\FailedImportRow as FilamentFailedImportRow;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+
+class FailedImportRow extends FilamentFailedImportRow
+{
+    use HasUlids;
+}

--- a/app/Models/Import.php
+++ b/app/Models/Import.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Filament\Actions\Imports\Models\Import as FilamentImport;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+
+class Import extends FilamentImport
+{
+    use HasUlids;
+}

--- a/app/Models/Import.php
+++ b/app/Models/Import.php
@@ -4,11 +4,29 @@ namespace App\Models;
 
 use Filament\Actions\Imports\Models\Import as FilamentImport;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Carbon;
 
 /**
+ * @property string $id
+ * @property ?Carbon $completed_at
+ * @property string|null $file_name
+ * @property string $file_path
+ * @property string $importer
+ * @property int $processed_rows
+ * @property int $total_rows
+ * @property int $successful_rows
+ * @property string $user_id
+ * @property ?Carbon $created_at
+ * @property ?Carbon $updated_at
  * @property-read User $user
+ *
+ * @method static \Database\Factories\ImportFactory factory(...$parameters)
  */
 class Import extends FilamentImport
 {
+    /** @use HasFactory<\Database\Factories\ImportFactory> */
+    use HasFactory;
+
     use HasUlids;
 }

--- a/app/Models/Import.php
+++ b/app/Models/Import.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use Filament\Actions\Imports\Models\Import as FilamentImport;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 
+/**
+ * @property-read User $user
+ */
 class Import extends FilamentImport
 {
     use HasUlids;

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -18,6 +18,8 @@ use Spatie\Translatable\HasTranslations;
  * @property Status $status
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ *
+ * @method static \Database\Factories\PageFactory factory(...$parameters)
  */
 class Page extends Model
 {

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -43,10 +43,10 @@ class Page extends Model
         'status' => Status::class,
     ];
 
-    /*
-     * @var string[]
+    /**
+     * @var list<string>
      */
-    protected $guarded = [];
+    protected $fillable = ['creator_id', 'title', 'content', 'status'];
 
     public function isReferenced(): bool
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,6 +22,9 @@ use Laravel\Jetstream\Jetstream;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 
+/**
+ * @method static \Database\Factories\UserFactory factory(mixed $count = null)
+ */
 class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerifyEmail
 {
     use HasApiTokens;

--- a/app/Policies/ExportPolicy.php
+++ b/app/Policies/ExportPolicy.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Export;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ExportPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Export $export): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view all models.
+     */
+    public function viewAll(User $user): bool
+    {
+        return $user->can('view_all_export');
+    }
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Export $export): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Export $export): bool
+    {
+        if ($user->isNot($export->user) && ! $this->viewAll($user)) {
+            return false;
+        }
+
+        return $user->can('delete_export');
+    }
+}

--- a/app/Policies/ExportPolicy.php
+++ b/app/Policies/ExportPolicy.php
@@ -15,7 +15,11 @@ class ExportPolicy
      */
     public function view(User $user, Export $export): bool
     {
-        return false;
+        if ($user->isNot($export->user) && ! $this->viewAll($user)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -59,6 +63,6 @@ class ExportPolicy
             return false;
         }
 
-        return $user->can('delete_export');
+        return true;
     }
 }

--- a/app/Policies/ImportPolicy.php
+++ b/app/Policies/ImportPolicy.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Import;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ImportPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Import $import): bool
+    {
+        if ($user->isNot($import->user) && ! $this->viewAll($user)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view all models.
+     */
+    public function viewAll(User $user): bool
+    {
+        return $user->can('view_all_import');
+    }
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Import $import): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Import $import): bool
+    {
+        if ($user->isNot($import->user) && ! $this->viewAll($user)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use App\Contracts\Jwt;
 use App\Services\AhcJwtService;
 use App\Services\DeviceService;
 use Exception;
+use Filament\Notifications\Livewire\DatabaseNotifications;
 use Filament\Support\Facades\FilamentColor;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Support\Facades\FilamentView;
@@ -36,6 +37,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        DatabaseNotifications::trigger('filament.notifications.database-notifications-trigger');
         FilamentColor::register([
             'primary' => Color::Vermilion,
             'secondary' => Color::WebOrange,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,9 +4,15 @@ namespace App\Providers;
 
 use App\Colors\Color;
 use App\Contracts\Jwt;
+use App\Models\Export;
+use App\Models\FailedImportRow;
+use App\Models\Import;
 use App\Services\AhcJwtService;
 use App\Services\DeviceService;
 use Exception;
+use Filament\Actions\Exports\Models\Export as FilamentExport;
+use Filament\Actions\Imports\Models\FailedImportRow as FilamentFailedImportRow;
+use Filament\Actions\Imports\Models\Import as FilamentImport;
 use Filament\Notifications\Livewire\DatabaseNotifications;
 use Filament\Support\Facades\FilamentColor;
 use Filament\Support\Facades\FilamentIcon;
@@ -30,6 +36,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(Jwt::class, function (Application $app) {
             return new AhcJwtService;
         });
+
+        $this->app->bind(FilamentExport::class, Export::class);
+        $this->app->bind(FilamentImport::class, Import::class);
+        $this->app->bind(FilamentFailedImportRow::class, FailedImportRow::class);
     }
 
     /**

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -138,6 +138,7 @@ class AdminPanelProvider extends PanelProvider
             ->viteTheme('resources/css/app.css')
             ->widgets([
                 \Awcodes\Overlook\Widgets\OverlookWidget::class,
-            ]);
+            ])
+            ->databaseNotifications();
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -80,6 +80,8 @@ class AdminPanelProvider extends PanelProvider
                 NavigationGroup::make()
                     ->label(fn () => __('Administration')),
                 NavigationGroup::make()
+                    ->label(fn () => __('Data Management')),
+                NavigationGroup::make()
                     ->label(fn () => __('filament-spatie-backup::backup.pages.backups.navigation.group')),
                 NavigationGroup::make()
                     ->label(fn () => __('filament-shield::filament-shield.nav.group')),

--- a/database/factories/ExportFactory.php
+++ b/database/factories/ExportFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Export>
+ */
+class ExportFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => \App\Models\User::factory(),
+            'completed_at' => $this->faker->boolean(50) ? $this->faker->dateTimeBetween('-1 month', 'now') : null,
+            'file_disk' => 'public', // As used in the test
+            'file_name' => $this->faker->boolean(80) ? 'exports/'.\Illuminate\Support\Str::ulid().'.csv' : null,
+            'exporter' => $this->faker->word().'Exporter',
+            'processed_rows' => $this->faker->numberBetween(0, 1000),
+            'total_rows' => $this->faker->numberBetween(1000, 2000),
+            'successful_rows' => $this->faker->numberBetween(0, 1000),
+        ];
+    }
+}

--- a/database/factories/ImportFactory.php
+++ b/database/factories/ImportFactory.php
@@ -18,8 +18,8 @@ class ImportFactory extends Factory
     public function definition(): array
     {
         return [
-            'completed_at' => $this->faker->boolean(70) ? $this->faker->dateTimeBetween('-1 month', 'now') : null,
-            'file_name' => $this->faker->boolean(80) ? 'imports/'.\Illuminate\Support\Str::ulid().'.csv' : null,
+            'completed_at' => $this->faker->dateTimeBetween('-1 month', 'now'),
+            'file_name' => 'imports/'.\Illuminate\Support\Str::ulid().'.csv',
             'file_path' => 'imports/'.\Illuminate\Support\Str::ulid().'.csv',
             'importer' => $this->faker->randomElement(['UserImporter', 'ProductImporter', 'OrderImporter']),
             'processed_rows' => $processed = $this->faker->numberBetween(10, 1000),

--- a/database/factories/ImportFactory.php
+++ b/database/factories/ImportFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User; // Assuming User model exists and is needed for user_id
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Import>
+ */
+class ImportFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'completed_at' => $this->faker->boolean(70) ? $this->faker->dateTimeBetween('-1 month', 'now') : null,
+            'file_name' => $this->faker->boolean(80) ? 'imports/'.\Illuminate\Support\Str::ulid().'.csv' : null,
+            'file_path' => 'imports/'.\Illuminate\Support\Str::ulid().'.csv',
+            'importer' => $this->faker->randomElement(['UserImporter', 'ProductImporter', 'OrderImporter']),
+            'processed_rows' => $processed = $this->faker->numberBetween(10, 1000),
+            'total_rows' => $total = $this->faker->numberBetween($processed, $processed + 500),
+            'successful_rows' => $this->faker->numberBetween(0, $processed),
+            'user_id' => User::factory(), // Assumes User factory exists
+        ];
+    }
+}

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\Page\Status;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -27,6 +28,7 @@ class PageFactory extends Factory
             'creator_id' => $creator->id,
             'title' => json_encode($title),
             'content' => $content ? json_encode(['en' => $content]) : null,
+            'status' => Status::Draft,
         ];
     }
 }

--- a/database/migrations/0001_01_01_000010_create_notifications_table.php
+++ b/database/migrations/0001_01_01_000010_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/database/migrations/0001_01_01_000010_create_notifications_table.php
+++ b/database/migrations/0001_01_01_000010_create_notifications_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('notifications', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('type');
-            $table->morphs('notifiable');
+            $table->ulidMorphs('notifiable');
             $table->text('data');
             $table->timestamp('read_at')->nullable();
             $table->timestamps();

--- a/database/migrations/0001_01_01_000011_create_exports_table.php
+++ b/database/migrations/0001_01_01_000011_create_exports_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exports', function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('completed_at')->nullable();
+            $table->string('file_disk');
+            $table->string('file_name')->nullable();
+            $table->string('exporter');
+            $table->unsignedInteger('processed_rows')->default(0);
+            $table->unsignedInteger('total_rows');
+            $table->unsignedInteger('successful_rows')->default(0);
+            $table->foreignUlid('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exports');
+    }
+};

--- a/database/migrations/0001_01_01_000011_create_exports_table.php
+++ b/database/migrations/0001_01_01_000011_create_exports_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('exports', function (Blueprint $table) {
-            $table->id();
+            $table->ulid('id')->primary();
             $table->timestamp('completed_at')->nullable();
             $table->string('file_disk');
             $table->string('file_name')->nullable();

--- a/database/migrations/0001_01_01_000012_create_imports_table.php
+++ b/database/migrations/0001_01_01_000012_create_imports_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('imports', function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('completed_at')->nullable();
+            $table->string('file_name');
+            $table->string('file_path');
+            $table->string('importer');
+            $table->unsignedInteger('processed_rows')->default(0);
+            $table->unsignedInteger('total_rows');
+            $table->unsignedInteger('successful_rows')->default(0);
+            $table->foreignUlid('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('imports');
+    }
+};

--- a/database/migrations/0001_01_01_000012_create_imports_table.php
+++ b/database/migrations/0001_01_01_000012_create_imports_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('imports', function (Blueprint $table) {
-            $table->id();
+            $table->ulid('id')->primary();
             $table->timestamp('completed_at')->nullable();
             $table->string('file_name');
             $table->string('file_path');

--- a/database/migrations/0001_01_01_000013_create_failed_import_rows_table.php
+++ b/database/migrations/0001_01_01_000013_create_failed_import_rows_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('failed_import_rows', function (Blueprint $table) {
+            $table->id();
+            $table->json('data');
+            $table->foreignId('import_id')->constrained()->cascadeOnDelete();
+            $table->text('validation_error')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_import_rows');
+    }
+};

--- a/database/migrations/0001_01_01_000013_create_failed_import_rows_table.php
+++ b/database/migrations/0001_01_01_000013_create_failed_import_rows_table.php
@@ -12,9 +12,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('failed_import_rows', function (Blueprint $table) {
-            $table->id();
+            $table->ulid('id')->primary();
             $table->json('data');
-            $table->foreignId('import_id')->constrained()->cascadeOnDelete();
+            $table->foreignUlid('import_id')->constrained()->cascadeOnDelete();
             $table->text('validation_error')->nullable();
             $table->timestamps();
         });

--- a/lang/en.json
+++ b/lang/en.json
@@ -75,6 +75,7 @@
     "Created.": "Created.",
     "Current Password": "Current Password",
     "Dashboard": "Dashboard",
+    "Data Management": "Data Management",
     "Delete": "Delete",
     "Delete :name": "Delete :name",
     "Delete Account": "Delete Account",

--- a/lang/en/export.php
+++ b/lang/en/export.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'navigation_group' => 'Data Management',
     'exporter' => 'Exporter',
     'file_name' => 'File Name',
     'file_disk' => 'File Disk',

--- a/lang/en/export.php
+++ b/lang/en/export.php
@@ -9,4 +9,5 @@ return [
     'successful_rows' => 'Successful Rows',
     'initiated_by' => 'Initiated By',
     'completed_at' => 'Completed At',
+    'download_name' => 'Download :name',
 ];

--- a/lang/en/export.php
+++ b/lang/en/export.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'navigation_group' => 'Data Management',
+    'exporter' => 'Exporter',
+    'file_name' => 'File Name',
+    'file_disk' => 'File Disk',
+    'total_rows' => 'Total Rows',
+    'processed_rows' => 'Processed Rows',
+    'successful_rows' => 'Successful Rows',
+    'initiated_by' => 'Initiated By',
+    'completed_at' => 'Completed At',
+];

--- a/lang/en/import.php
+++ b/lang/en/import.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'file_name' => 'File Name',
+    'importer' => 'Importer',
+    'total_rows' => 'Total Rows',
+    'processed_rows' => 'Processed Rows',
+    'user' => 'User',
+    'failed_imports' => 'Failed Imports',
+    'file_path' => 'File Path',
+    'successful_rows' => 'Successful Rows',
+    'completed_at' => 'Completed At',
+];

--- a/lang/en/page.php
+++ b/lang/en/page.php
@@ -14,4 +14,6 @@ return [
     ],
     'export_completed' => 'Your page export has completed and :successful_rows row(s) exported.',
     'export_failed' => ':failed_rows row(s) failed to export.',
+    'import_completed' => '<strong>:successful_rows</strong> row(s) imported.',
+    'import_failed' => '<strong>:failed_rows</strong> row(s) failed to import.',
 ];

--- a/lang/en/page.php
+++ b/lang/en/page.php
@@ -12,4 +12,6 @@ return [
         ],
         'title' => 'Title',
     ],
+    'export_completed' => 'Your page export has completed and :successful_rows row(s) exported.',
+    'export_failed' => ':failed_rows row(s) failed to export.',
 ];

--- a/lang/en/page.php
+++ b/lang/en/page.php
@@ -14,6 +14,6 @@ return [
     ],
     'export_completed' => 'Your page export has completed and :successful_rows row(s) exported.',
     'export_failed' => ':failed_rows row(s) failed to export.',
-    'import_completed' => '<strong>:successful_rows</strong> row(s) imported.',
-    'import_failed' => '<strong>:failed_rows</strong> row(s) failed to import.',
+    'import_completed' => ':successful_rows row(s) imported.',
+    'import_failed' => ':failed_rows row(s) failed to import.',
 ];

--- a/lang/id.json
+++ b/lang/id.json
@@ -75,6 +75,7 @@
     "Created.": "Dibuat.",
     "Current Password": "Kata Sandi Saat Ini",
     "Dashboard": "Dasbor",
+    "Data Management": "Manajemen Data",
     "Delete": "Hapus",
     "Delete :name": "Hapus :name",
     "Delete Account": "Hapus Akun",

--- a/lang/id/export.php
+++ b/lang/id/export.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'navigation_group' => 'Manajemen Data',
     'exporter' => 'Eksportir',
     'file_name' => 'Nama File',
     'file_disk' => 'Disk File',

--- a/lang/id/export.php
+++ b/lang/id/export.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'navigation_group' => 'Manajemen Data',
+    'exporter' => 'Eksportir',
+    'file_name' => 'Nama File',
+    'file_disk' => 'Disk File',
+    'total_rows' => 'Jumlah Baris',
+    'processed_rows' => 'Baris yang Diproses',
+    'successful_rows' => 'Baris yang Berhasil',
+    'initiated_by' => 'Diprakarsai Oleh',
+    'completed_at' => 'Selesai Pada',
+];

--- a/lang/id/export.php
+++ b/lang/id/export.php
@@ -9,4 +9,5 @@ return [
     'successful_rows' => 'Baris yang Berhasil',
     'initiated_by' => 'Diprakarsai Oleh',
     'completed_at' => 'Selesai Pada',
+    'download_name' => 'Unduh :name',
 ];

--- a/lang/id/import.php
+++ b/lang/id/import.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'file_name' => 'Nama Berkas',
+    'importer' => 'Pengimpor',
+    'total_rows' => 'Total Baris',
+    'processed_rows' => 'Baris Diproses',
+    'user' => 'Pengguna',
+    'failed_imports' => 'Impor Gagal',
+    'file_path' => 'Jalur Berkas',
+    'successful_rows' => 'Baris Berhasil',
+    'completed_at' => 'Selesai Pada',
+];

--- a/lang/id/page.php
+++ b/lang/id/page.php
@@ -14,6 +14,6 @@ return [
     ],
     'export_completed' => 'Ekspor halaman Anda telah selesai dan :successful_rows baris berhasil diekspor.',
     'export_failed' => ':failed_rows baris gagal diekspor.',
-    'import_completed' => '<strong>:successful_rows</strong> baris berhasil diimpor.',
-    'import_failed' => '<strong>:failed_rows</strong> baris gagal diimpor.',
+    'import_completed' => ':successful_rows baris berhasil diimpor.',
+    'import_failed' => ':failed_rows baris gagal diimpor.',
 ];

--- a/lang/id/page.php
+++ b/lang/id/page.php
@@ -14,4 +14,6 @@ return [
     ],
     'export_completed' => 'Ekspor halaman Anda telah selesai dan :successful_rows baris berhasil diekspor.',
     'export_failed' => ':failed_rows baris gagal diekspor.',
+    'import_completed' => '<strong>:successful_rows</strong> baris berhasil diimpor.',
+    'import_failed' => '<strong>:failed_rows</strong> baris gagal diimpor.',
 ];

--- a/lang/id/page.php
+++ b/lang/id/page.php
@@ -12,4 +12,6 @@ return [
         ],
         'title' => 'Judul',
     ],
+    'export_completed' => 'Ekspor halaman Anda telah selesai dan :successful_rows baris berhasil diekspor.',
+    'export_failed' => ':failed_rows baris gagal diekspor.',
 ];

--- a/resources/views/filament/notifications/database-notifications-trigger.blade.php
+++ b/resources/views/filament/notifications/database-notifications-trigger.blade.php
@@ -1,0 +1,7 @@
+<x-filament::icon-button size="lg" color="gray" icon="heroicon-o-bell" label="Mark notifications as read">
+    <x-slot name="badge">
+        @if ($unreadNotificationsCount > 0)
+            {{ $unreadNotificationsCount }}
+        @endif
+    </x-slot>
+</x-filament::icon-button>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -30,6 +30,11 @@
             </div>
 
             <div class="flex flex-row items-center gap-2">
+                <!-- Notifications Trigger -->
+                <div class="relative">
+                    @livewire('database-notifications')
+                </div>
+
                 <!-- Language Switcher -->
                 <div class="relative">
                     <x-navigation-menu.language-switcher />

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -30,10 +30,12 @@
             </div>
 
             <div class="flex flex-row items-center gap-2">
-                <!-- Notifications Trigger -->
-                <div class="relative">
-                    @livewire('database-notifications')
-                </div>
+                @auth
+                    <!-- Notifications Trigger -->
+                    <div class="relative">
+                        @livewire('database-notifications')
+                    </div>
+                @endauth
 
                 <!-- Language Switcher -->
                 <div class="relative">

--- a/tests/Feature/Filament/Exports/PageExporterTest.php
+++ b/tests/Feature/Filament/Exports/PageExporterTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Feature\Filament\Exports;
+
+use App\Enums\Page\Status;
+use App\Filament\Exports\PageExporter;
+use Filament\Actions\Exports\ExportColumn;
+use Filament\Actions\Exports\Models\Export;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class PageExporterTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    public function test_returns_all_expected_columns(): void
+    {
+        $columns = PageExporter::getColumns();
+
+        $this->assertCount(7, $columns); // id, creator_id, title, content, status, created_at, updated_at
+
+        $columnNames = array_map(fn (ExportColumn $column) => $column->getName(), $columns);
+
+        $this->assertEquals([
+            'id',
+            'creator_id',
+            'title',
+            'content',
+            'status',
+            'created_at',
+            'updated_at',
+        ], $columnNames);
+
+        // Optionally, check labels for specific columns if they are set
+        $idColumn = collect($columns)->first(fn (ExportColumn $column) => $column->getName() === 'id');
+        $this->assertEquals('ID', $idColumn?->getLabel());
+    }
+
+    public function test_status_column_correctly_formats_state(): void
+    {
+        $columns = PageExporter::getColumns();
+        $statusColumn = collect($columns)->first(fn (ExportColumn $column) => $column->getName() === 'status');
+        $this->assertNotNull($statusColumn, 'Status column not found.');
+
+        // Access the formatStateUsing closure directly from the column's internal properties
+        // This is a workaround as getFormatStateUsing() is not public.
+        // In a real application, you might test the output of the exporter directly.
+        $reflection = new \ReflectionClass($statusColumn);
+        $property = $reflection->getProperty('formatStateUsing');
+        $property->setAccessible(true);
+        $formatStateUsing = $property->getValue($statusColumn);
+
+        $this->assertIsCallable($formatStateUsing);
+
+        // Test with a specific Status enum value
+        $draftStatus = Status::Draft;
+        $formattedDraft = $formatStateUsing($draftStatus);
+        $this->assertEquals($draftStatus->value, $formattedDraft);
+
+        $publishedStatus = Status::Publish;
+        $formattedPublished = $formatStateUsing($publishedStatus);
+        $this->assertEquals($publishedStatus->value, $formattedPublished);
+    }
+
+    public function test_returns_correct_notification_body_for_successful_export(): void
+    {
+        $this->app->setLocale('en'); // Set locale to 'en'
+
+        $export = new Export;
+        $export->total_rows = 100;
+        $export->successful_rows = 100;
+
+        $body = PageExporter::getCompletedNotificationBody($export);
+
+        $this->assertEquals(__('page.export_completed', ['successful_rows' => number_format($export->successful_rows)]), $body);
+    }
+
+    public function test_returns_correct_notification_body_for_export_with_failed_rows(): void
+    {
+        $this->app->setLocale('en'); // Set locale to 'en'
+
+        $export = new Export;
+        $export->total_rows = 200;
+        $export->successful_rows = 100;
+        $failedRowsCount = $export->total_rows - $export->successful_rows;
+
+        $body = PageExporter::getCompletedNotificationBody($export);
+
+        $messageParts = [__('page.export_completed', ['successful_rows' => number_format($export->successful_rows)])];
+
+        $messageParts[] = __('page.export_failed', ['failed_rows' => number_format($failedRowsCount)]);
+
+        $message = implode(' ', $messageParts);
+
+        $this->assertEquals($message, $body);
+    }
+
+    public function test_handles_different_successful_and_failed_row_counts(): void
+    {
+        $this->app->setLocale('en'); // Set locale to 'en'
+
+        // Case 1: Only successful rows
+        $export1 = new Export;
+        $export1->total_rows = 5;
+        $export1->successful_rows = 5;
+        $this->assertEquals(__('page.export_completed', ['successful_rows' => number_format($export1->successful_rows)]), PageExporter::getCompletedNotificationBody($export1));
+
+        // Case 2: Successful and failed rows
+        $export2 = new Export;
+        $export2->total_rows = 2;
+        $export2->successful_rows = 1;
+        $failedRowsCount2 = $export2->total_rows - $export2->successful_rows;
+        $messageParts2 = [__('page.export_completed', ['successful_rows' => number_format($export2->successful_rows)])];
+        $messageParts2[] = __('page.export_failed', ['failed_rows' => number_format($failedRowsCount2)]);
+        $message2 = implode(' ', $messageParts2);
+        $this->assertEquals($message2, PageExporter::getCompletedNotificationBody($export2));
+
+        // Case 3: Large numbers
+        $export3 = new Export;
+        $export3->total_rows = 1500000;
+        $export3->successful_rows = 1000000;
+        $failedRowsCount3 = $export3->total_rows - $export3->successful_rows;
+        $messageParts3 = [__('page.export_completed', ['successful_rows' => number_format($export3->successful_rows)])];
+        $messageParts3[] = __('page.export_failed', ['failed_rows' => number_format($failedRowsCount3)]);
+        $message3 = implode(' ', $messageParts3);
+        $this->assertEquals($message3, PageExporter::getCompletedNotificationBody($export3));
+    }
+}

--- a/tests/Feature/Filament/Exports/PageExporterTest.php
+++ b/tests/Feature/Filament/Exports/PageExporterTest.php
@@ -6,7 +6,6 @@ use App\Enums\Page\Status;
 use App\Filament\Exports\PageExporter;
 use App\Models\Permission;
 use App\Models\User;
-use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Models\Export;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -19,28 +18,8 @@ class PageExporterTest extends TestCase
 
     public function test_status_column_correctly_formats_state(): void
     {
-        $columns = PageExporter::getColumns();
-        $statusColumn = collect($columns)->first(fn (ExportColumn $column) => $column->getName() === 'status');
-        $this->assertNotNull($statusColumn, 'Status column not found.');
-
-        // Access the formatStateUsing closure directly from the column's internal properties
-        // This is a workaround as getFormatStateUsing() is not public.
-        // In a real application, you might test the output of the exporter directly.
-        $reflection = new \ReflectionClass($statusColumn);
-        $property = $reflection->getProperty('formatStateUsing');
-        $property->setAccessible(true);
-        $formatStateUsing = $property->getValue($statusColumn);
-
-        $this->assertIsCallable($formatStateUsing);
-
-        // Test with a specific Status enum value
-        $draftStatus = Status::Draft;
-        $formattedDraft = $formatStateUsing($draftStatus);
-        $this->assertEquals($draftStatus->value, $formattedDraft);
-
-        $publishedStatus = Status::Publish;
-        $formattedPublished = $formatStateUsing($publishedStatus);
-        $this->assertEquals($publishedStatus->value, $formattedPublished);
+        $this->assertEquals(Status::Draft->value, PageExporter::formatStatus(Status::Draft));
+        $this->assertEquals(Status::Publish->value, PageExporter::formatStatus(Status::Publish));
     }
 
     public function test_returns_correct_notification_body_for_successful_export(): void

--- a/tests/Feature/Filament/Exports/PageExporterTest.php
+++ b/tests/Feature/Filament/Exports/PageExporterTest.php
@@ -15,29 +15,6 @@ class PageExporterTest extends TestCase
     use RefreshDatabase;
     use WithFaker;
 
-    public function test_returns_all_expected_columns(): void
-    {
-        $columns = PageExporter::getColumns();
-
-        $this->assertCount(7, $columns); // id, creator_id, title, content, status, created_at, updated_at
-
-        $columnNames = array_map(fn (ExportColumn $column) => $column->getName(), $columns);
-
-        $this->assertEquals([
-            'id',
-            'creator_id',
-            'title',
-            'content',
-            'status',
-            'created_at',
-            'updated_at',
-        ], $columnNames);
-
-        // Optionally, check labels for specific columns if they are set
-        $idColumn = collect($columns)->first(fn (ExportColumn $column) => $column->getName() === 'id');
-        $this->assertEquals('ID', $idColumn?->getLabel());
-    }
-
     public function test_status_column_correctly_formats_state(): void
     {
         $columns = PageExporter::getColumns();

--- a/tests/Feature/Filament/Imports/PageImporterTest.php
+++ b/tests/Feature/Filament/Imports/PageImporterTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Tests\Feature\Filament\Imports;
+
+use App\Enums\Page\Status;
+use App\Filament\Imports\PageImporter;
+use App\Models\Import;
+use App\Models\Page;
+use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PageImporterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_create_a_new_page_when_id_is_not_present_in_data(): void
+    {
+        // Arrange
+        $user = User::factory()->create(); // Create a user for creator_id
+        $this->actingAs($user);
+
+        $initialPageCount = Page::count(); // Get the initial count of pages
+
+        $data = [
+            'title' => 'Test Page',
+            'content' => 'Test Content',
+            'status' => 'draft',
+            'creator_id' => $user->id, // Use the created user's ID
+        ];
+
+        // Act
+        $import = Import::factory()->create([
+            'total_rows' => 0,
+            'successful_rows' => 0,
+        ]);
+
+        $columnMap = [
+            'title' => 'title',
+            'content' => 'content',
+            'status' => 'status',
+            'creator_id' => 'creator_id',
+        ];
+        $importer = new PageImporter($import, $columnMap, []);
+        $importer($data); // Call __invoke to set the internal $data property
+        $page = $importer->getRecord();
+
+        // Assert
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertEquals($initialPageCount + 1, Page::count()); // Assert one new page was created
+
+        $this->assertEquals($data['title'], $page->title);
+        $this->assertEquals($data['content'], $page->content);
+        $this->assertEquals('draft', $page->status->value);
+
+        // Optionally, assert that the page exists in the database
+        $this->assertDatabaseHas('pages', [
+            'status' => 'draft',
+            'creator_id' => $user->id,
+            'id' => $page->id,
+        ]);
+
+        // Retrieve the page from the database to ensure Laravel's casts are applied
+        $retrievedPage = Page::find($page->id); // Assuming App\Models\Page is your model namespace
+
+        // Assert the JSON fields by comparing the PHP arrays
+        $this->assertEquals($data['title'], $retrievedPage?->title);
+        $this->assertEquals($data['content'], $retrievedPage?->content);
+    }
+
+    public function test_can_update_an_existing_page_when_id_is_present_and_matches(): void
+    {
+        // Arrange
+        $user = User::factory()->create(); // Create a user for creator_id
+        $this->actingAs($user);
+
+        $existingPage = Page::factory()->create();
+        $initialPageCount = Page::count(); // Get the initial count of pages
+
+        $data = [
+            'id' => $existingPage->id,
+            'title' => 'Updated Title',
+            'content' => 'Updated Content',
+            'status' => 'publish',
+            'creator_id' => $user->id, // Use the created user's ID
+        ];
+
+        // Act
+        $import = Import::factory()->create([
+            'total_rows' => 0,
+            'successful_rows' => 0,
+        ]);
+
+        $columnMap = [
+            'id' => 'id',
+            'title' => 'title',
+            'content' => 'content',
+            'status' => 'status',
+            'creator_id' => 'creator_id',
+        ];
+        $importer = new PageImporter($import, $columnMap, []);
+        $importer($data); // Call __invoke to set the internal $data property
+        $page = $importer->getRecord();
+
+        // Assert
+        $this->assertInstanceOf(Page::class, $page);
+        $this->assertEquals($initialPageCount, Page::count()); // Assert no new page was created, only updated
+        $this->assertEquals($data['title'], $page->title);
+        $this->assertEquals($data['content'], $page->content);
+        $this->assertEquals('publish', $page->status->value);
+
+        // Optionally, assert that the page exists in the database
+        $this->assertDatabaseHas('pages', [
+            'id' => $existingPage->id,
+            'status' => 'publish',
+            'creator_id' => $user->id,
+        ]);
+
+        // Retrieve the page from the database to ensure Laravel's casts are applied
+        $retrievedPage = Page::find($page->id); // Assuming App\Models\Page is your model namespace
+
+        // Assert the JSON fields by comparing the PHP arrays
+        $this->assertEquals($data['title'], $retrievedPage?->title);
+        $this->assertEquals($data['content'], $retrievedPage?->content);
+    }
+
+    public function test_handles_creator_id_when_present_in_import_data_and_user_has_view_all_permission(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        Permission::firstOrCreate(['name' => 'view_all_page']);
+        $user->givePermissionTo('view_all_page');
+        $this->actingAs($user);
+
+        $otherUser = User::factory()->create();
+
+        $data = [
+            'creator_id' => $otherUser->id, // Different creator ID
+            'title' => 'Test Page',
+            'content' => 'Test Content',
+            'status' => 'draft',
+        ];
+
+        // Act
+        $import = Import::factory()->create([
+            'total_rows' => 0,
+            'successful_rows' => 0,
+        ]);
+
+        $columnMap = [
+            'title' => 'title',
+            'content' => 'content',
+            'status' => 'status',
+            'creator_id' => 'creator_id',
+        ];
+        $importer = new PageImporter($import, $columnMap, []);
+        $importer($data);
+        /** @var Page */
+        $page = $importer->getRecord();
+
+        // Assert
+        $this->assertEquals($otherUser->id, $page->creator_id);
+    }
+
+    public function test_handles_creator_id_when_present_in_import_data_and_user_does_not_have_view_all_permission(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $otherUser = User::factory()->create();
+
+        $data = [
+            'creator_id' => $otherUser->id, // Different creator ID
+            'title' => 'Test Page',
+            'content' => 'Test Content',
+            'status' => 'draft',
+        ];
+
+        // Act
+        $import = Import::factory()->create([
+            'total_rows' => 0,
+            'successful_rows' => 0,
+        ]);
+
+        $columnMap = [
+            'title' => 'title',
+            'content' => 'content',
+            'status' => 'status',
+            'creator_id' => 'creator_id',
+        ];
+        $importer = new PageImporter($import, $columnMap, []);
+        $importer($data);
+        /** @var Page */
+        $page = $importer->getRecord();
+
+        // Assert
+        $this->assertEquals($user->id, $page->creator_id);
+    }
+
+    public function test_handles_creator_id_when_absent_in_import_data(): void
+    {
+        // Arrange
+        $currentUser = User::factory()->create();
+        $this->actingAs($currentUser);
+        $data = [
+            'title' => 'Test Page',
+            'content' => 'Test Content',
+            'status' => 'draft',
+        ];
+
+        // Act
+        $import = Import::factory()->create([
+            'total_rows' => 0,
+            'successful_rows' => 0,
+        ]);
+        $columnMap = [
+            'title' => 'title',
+            'content' => 'content',
+            'status' => 'status',
+        ];
+        $importer = new PageImporter($import, $columnMap, []);
+        $importer($data);
+        /** @var Page */
+        $page = $importer->getRecord();
+
+        // Assert
+        $this->assertEquals($currentUser->id, $page->creator_id);
+    }
+
+    public function test_handles_status_enum_during_import(): void
+    {
+        // Arrange
+        $this->actingAs(User::factory()->create());
+        $data = [
+            'title' => 'Test Page',
+            'content' => 'Test Content',
+            'status' => 'publish',
+        ];
+
+        // Act
+        $import = Import::factory()->create([
+            'total_rows' => 0,
+            'successful_rows' => 0,
+        ]);
+        $columnMap = [
+            'title' => 'title',
+            'content' => 'content',
+            'status' => 'status',
+        ];
+        $importer = new PageImporter($import, $columnMap, []);
+        $importer($data);
+        /** @var Page */
+        $page = $importer->getRecord();
+
+        // Assert
+        $this->assertEquals(Status::Publish, $page->status);
+    }
+}

--- a/tests/Feature/Filament/Resources/ExportResourceTest.php
+++ b/tests/Feature/Filament/Resources/ExportResourceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\Filament\Resources;
+
+use App\Filament\Resources\ExportResource;
+use App\Models\Export;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ExportResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_export_table_can_be_rendered(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $this->get(ExportResource::getUrl('index'))->assertSuccessful();
+    }
+
+    public function test_columns_are_displayed(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Export::factory()->create([
+            'user_id' => $user->id,
+            'exporter' => 'App\\Exporters\\PageExporter',
+            'file_name' => 'test.csv',
+            'file_disk' => 'local',
+            'total_rows' => 100,
+            'processed_rows' => 50,
+            'successful_rows' => 50,
+            'completed_at' => now(),
+        ]);
+
+        $this->get(ExportResource::getUrl('index'))
+            ->assertSee('Page') // From exporter column
+            ->assertSee('local')
+            ->assertSee('100')
+            ->assertSee('50');
+    }
+
+    public function test_download_actions_are_present(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $export = Export::factory()->create([
+            'user_id' => $user->id,
+            'file_name' => 'test.csv',
+            'file_disk' => 'local',
+        ]);
+
+        $this->get(ExportResource::getUrl('index'))
+            ->assertSee(__('export.download_name', ['name' => 'CSV']))
+            ->assertSee(__('export.download_name', ['name' => 'XLSX']));
+    }
+
+    public function test_get_eloquent_query_filters_results_for_non_admin_users(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Export::factory()->create(['user_id' => $user->id]);
+        Export::factory()->create(['user_id' => User::factory()->create()->id]);
+
+        $exports = ExportResource::getEloquentQuery()->get();
+
+        $this->assertCount(1, $exports);
+        $this->assertEquals($user->id, $exports->first()?->user_id);
+    }
+}

--- a/tests/Feature/Filament/Resources/ImportResourceTest.php
+++ b/tests/Feature/Filament/Resources/ImportResourceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Feature\Filament\Resources;
+
+use App\Filament\Resources\ImportResource;
+use App\Filament\Resources\ImportResource\Pages\ListImports;
+use App\Models\Import;
+use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ImportResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_import_table_can_be_rendered(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $this->get(ImportResource::getUrl('index'))->assertSuccessful();
+    }
+
+    public function test_columns_are_displayed(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Import::factory()->create([
+            'user_id' => $user->id,
+            'importer' => 'App\\Importers\\PageImporter',
+            'file_name' => 'import_test.csv',
+            'file_path' => '/tmp/import_test.csv',
+            'total_rows' => 150,
+            'processed_rows' => 100,
+            'successful_rows' => 90,
+            'completed_at' => now(),
+        ]);
+
+        // Mock the trans_choice function for the importer column
+        // This is necessary because the resource uses trans_choice which might not be available
+        // or correctly configured in a feature test without a full application context.
+        \Illuminate\Support\Facades\Lang::shouldReceive('trans_choice')
+            ->with('page.resource.model_label', 1)
+            ->andReturn('Page');
+
+        $this->get(ImportResource::getUrl('index'))
+            ->assertSee('Page') // From importer column
+            ->assertSee('import_test.csv')
+            ->assertSee('150')
+            ->assertSee('100')
+            ->assertSee('90');
+    }
+
+    public function test_get_eloquent_query_filters_results_for_non_view_all_users(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // Ensure the user does NOT have 'view_all_import' permission
+        // No permission assignment needed here as it's the default state
+
+        Import::factory()->create(['user_id' => $user->id]);
+        Import::factory()->create(['user_id' => User::factory()->create()->id]); // Another user's import
+
+        $imports = ImportResource::getEloquentQuery()->get();
+
+        $this->assertCount(1, $imports);
+        $this->assertEquals($user->id, $imports->first()?->user_id);
+    }
+
+    public function test_get_eloquent_query_does_not_filter_results_for_view_all_users(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // Assign 'view_all_import' permission to the user
+        Permission::firstOrCreate(['name' => 'view_all_import']);
+        $user->givePermissionTo('view_all_import');
+
+        Import::factory()->create(['user_id' => $user->id]);
+        Import::factory()->create(['user_id' => User::factory()->create()->id]); // Another user's import
+
+        $imports = ImportResource::getEloquentQuery()->get();
+
+        $this->assertCount(2, $imports);
+    }
+
+    public function test_user_name_column_visibility_for_view_all_users(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // Assign 'view_all_import' permission to the user
+        Permission::firstOrCreate(['name' => 'view_all_import']);
+        $user->givePermissionTo('view_all_import');
+
+        Import::factory()->create(['user_id' => $user->id]);
+
+        Livewire::test(ListImports::class)
+            ->assertTableColumnVisible('user.name');
+    }
+
+    public function test_user_name_column_hidden_for_non_view_all_users(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // Ensure the user does NOT have 'view_all_import' permission
+        // No permission assignment needed here as it's the default state
+
+        Import::factory()->create(['user_id' => $user->id]);
+
+        Livewire::test(ListImports::class)
+            ->assertTableColumnHidden('user.name');
+    }
+
+    public function test_importer_column_format_state_using(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Import::factory()->create([
+            'user_id' => $user->id,
+            'importer' => 'App\\Importers\\ProductImporter',
+        ]);
+
+        // Mock the trans_choice function for the importer column
+        \Illuminate\Support\Facades\Lang::shouldReceive('trans_choice')
+            ->with('product.resource.model_label', 1)
+            ->andReturn('Product');
+
+        $this->get(ImportResource::getUrl('index'))
+            ->assertSee('Product');
+    }
+}

--- a/tests/Feature/Models/ExportTest.php
+++ b/tests/Feature/Models/ExportTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Models\Export;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ExportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('public'); // Fake the 'public' disk for filesystem interactions
+    }
+
+    public function test_deletes_directory_on_export_deletion_void(): void
+    {
+        // Create a real Export model instance.
+        // We need to save it to the database for the 'deleted' event to fire correctly
+        // when we call $export->delete().
+        $export = Export::factory()->create([
+            'file_disk' => 'public', // Ensure it uses the faked disk
+        ]);
+
+        // The directory path is based on the model's key (ID)
+        $directoryPath = 'filament_exports'.DIRECTORY_SEPARATOR.$export->id;
+
+        // Ensure the directory "exists" on the faked disk before deletion
+        Storage::disk('public')->makeDirectory($directoryPath);
+        $this->assertTrue(Storage::disk('public')->exists($directoryPath), "The directory {$directoryPath} should exist.");
+
+        // Act: Delete the export model
+        // This will trigger the 'deleted' event, which our listener will catch
+        $export->delete();
+
+        // Assert: The directory should no longer exist on the faked disk
+        $this->assertFalse(Storage::disk('public')->exists($directoryPath), "The directory {$directoryPath} should be missing.");
+    }
+
+    public function test_does_not_delete_directory_if_not_exists_void(): void
+    {
+        // Create a real Export model instance
+        $export = Export::factory()->create([
+            'file_disk' => 'public',
+        ]);
+
+        $directoryPath = 'filament_exports'.DIRECTORY_SEPARATOR.$export->id;
+
+        // Assert that the directory does NOT exist initially
+        $this->assertFalse(Storage::disk('public')->exists($directoryPath), "The directory {$directoryPath} should be missing.");
+
+        // Act: Delete the export model
+        // The listener should check for existence before attempting deletion
+        $export->delete();
+
+        // Assert: The directory should still not exist (no change, no error)
+        $this->assertFalse(Storage::disk('public')->exists($directoryPath), "The directory {$directoryPath} should be missing.");
+    }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to Filament's import and export capabilities. It includes the addition of database notifications, Filament Import/Export resources with ULIDs, Export and Import resources to Filament, and comprehensive improvements to the Page Importer and Exporter. The changes encompass:

- Implementing database notifications for Filament admin panel and navigation.
- Introducing custom models for Filament Imports and Exports, utilizing ULIDs.
- Adding ExportResource and ImportResource to the Filament admin panel.
- Adding download actions for CSV and XLSX formats to the ExportResource table.
- Formatting exporter and importer columns in export/import resources tables
- Implementing an ExportPolicy and updating user association.
- Enhancing the Page Importer with status casting, creator ID handling, and title/content translation.
- Adding comprehensive tests for ExportResource, ImportResource, PageExporter, and PageImporter.
- Improving page import and export functionality, including gate checks for creator_id and JSON data handling.
- Adding validation rules to PageImporter to ensure data integrity.
- Refactoring PageImporter tests for localized content.
- Improving PageImporter logic and security to prevent unauthorized access and data manipulation.

These enhancements provide a more robust, secure, and user-friendly import/export experience within the Filament admin panel.