### PR TITLE
feat: implement creator tracking and improved access control for imports and exports

### DIFF
--- a/app/Filament/Resources/ExportResource.php
+++ b/app/Filament/Resources/ExportResource.php
@@ -32,8 +32,11 @@ class ExportResource extends Resource implements HasShieldPermissions
         $query = parent::getEloquentQuery();
 
         if (! static::canViewAll()) {
-            $query->where('user_id', Auth::id())
-                ->orWhere('creator_id', Auth::id());
+            // Use a closure to group the WHERE conditions correctly
+            $query->where(function (Builder $query) {
+                $query->where('user_id', Auth::id())
+                    ->orWhere('creator_id', Auth::id());
+            });
         }
 
         return $query;

--- a/app/Filament/Resources/ExportResource.php
+++ b/app/Filament/Resources/ExportResource.php
@@ -32,7 +32,8 @@ class ExportResource extends Resource implements HasShieldPermissions
         $query = parent::getEloquentQuery();
 
         if (! static::canViewAll()) {
-            $query->where('user_id', Auth::id());
+            $query->where('user_id', Auth::id())
+                ->orWhere('creator_id', Auth::id());
         }
 
         return $query;

--- a/app/Filament/Resources/ExportResource.php
+++ b/app/Filament/Resources/ExportResource.php
@@ -39,6 +39,11 @@ class ExportResource extends Resource implements HasShieldPermissions
         return $query;
     }
 
+    public static function getModelLabel(): string
+    {
+        return trans_choice('export.resource.model_label', 1);
+    }
+
     public static function getNavigationGroup(): ?string
     {
         return __('Data Management');
@@ -59,12 +64,17 @@ class ExportResource extends Resource implements HasShieldPermissions
         return ['view_all'];
     }
 
+    public static function getPluralModelLabel(): string
+    {
+        return trans_choice('export.resource.model_label', 2);
+    }
+
     public static function table(Table $table): Table
     {
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('exporter')
-                    ->label(__('export.exporter'))
+                    ->label(__('export.resource.exporter'))
                     ->searchable()
                     ->sortable()
                     ->formatStateUsing(function (string $state): string {
@@ -75,34 +85,39 @@ class ExportResource extends Resource implements HasShieldPermissions
                         return trans_choice("{$lowercasedModelName}.resource.model_label", 1);
                     }),
                 Tables\Columns\TextColumn::make('file_name')
-                    ->label(__('export.file_name'))
+                    ->label(__('export.resource.file_name'))
                     ->searchable()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('file_disk')
-                    ->label(__('export.file_disk'))
+                    ->label(__('export.resource.file_disk'))
                     ->searchable()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('total_rows')
-                    ->label(__('export.total_rows'))
+                    ->label(__('export.resource.total_rows'))
                     ->numeric()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('processed_rows')
-                    ->label(__('export.processed_rows'))
+                    ->label(__('export.resource.processed_rows'))
                     ->numeric()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('successful_rows')
-                    ->label(__('export.successful_rows'))
+                    ->label(__('export.resource.successful_rows'))
                     ->numeric()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('user.name')
-                    ->label(__('export.initiated_by'))
+                    ->label(__('export.resource.user'))
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true)
+                    ->visible(static::canViewAll()),
+                Tables\Columns\TextColumn::make('creator.name')
+                    ->label(ucfirst(__('validation.attributes.creator')))
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true)
                     ->visible(static::canViewAll()),
                 Tables\Columns\TextColumn::make('completed_at')
-                    ->label(__('export.completed_at'))
+                    ->label(__('export.resource.completed_at'))
                     ->dateTime()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('created_at')
@@ -120,13 +135,13 @@ class ExportResource extends Resource implements HasShieldPermissions
                 Tables\Actions\DeleteAction::make(),
                 Tables\Actions\ActionGroup::make([
                     Tables\Actions\Action::make('download_csv')
-                        ->label(__('export.download_name', ['name' => 'CSV']))
+                        ->label(__('export.resource.download_name', ['name' => 'CSV']))
                         ->icon('heroicon-o-document-arrow-down')
                         ->url(fn (Export $record): string => route('filament.exports.download', ['export' => $record->id, 'format' => 'csv']))
                         ->openUrlInNewTab()
                         ->visible(fn (Export $record) => filled($record->file_name) && filled($record->file_disk)),
                     Tables\Actions\Action::make('download_xlsx')
-                        ->label(__('export.download_name', ['name' => 'XLSX']))
+                        ->label(__('export.resource.download_name', ['name' => 'XLSX']))
                         ->icon('heroicon-o-document-arrow-down')
                         ->url(fn (Export $record): string => route('filament.exports.download', ['export' => $record->id, 'format' => 'xlsx']))
                         ->openUrlInNewTab()

--- a/app/Filament/Resources/ImportResource.php
+++ b/app/Filament/Resources/ImportResource.php
@@ -34,8 +34,11 @@ class ImportResource extends Resource implements HasShieldPermissions
         $query = parent::getEloquentQuery();
 
         if (! static::canViewAll()) {
-            $query->where('user_id', Auth::id())
-                ->orWhere('creator_id', Auth::id());
+            // Use a closure to group the WHERE conditions correctly
+            $query->where(function (Builder $query) {
+                $query->where('user_id', Auth::id())
+                    ->orWhere('creator_id', Auth::id());
+            });
         }
 
         return $query;

--- a/app/Filament/Resources/ImportResource.php
+++ b/app/Filament/Resources/ImportResource.php
@@ -41,6 +41,11 @@ class ImportResource extends Resource implements HasShieldPermissions
         return $query;
     }
 
+    public static function getModelLabel(): string
+    {
+        return trans_choice('import.resource.model_label', 1);
+    }
+
     public static function getNavigationGroup(): ?string
     {
         return __('Data Management');
@@ -59,12 +64,17 @@ class ImportResource extends Resource implements HasShieldPermissions
         return ['view_all'];
     }
 
+    public static function getPluralModelLabel(): string
+    {
+        return trans_choice('import.resource.model_label', 2);
+    }
+
     public static function table(Table $table): Table
     {
         return $table
             ->columns([
                 TextColumn::make('importer')
-                    ->label(__('import.importer'))
+                    ->label(__('import.resource.importer'))
                     ->searchable()
                     ->sortable()
                     ->formatStateUsing(function (string $state): string {
@@ -75,34 +85,39 @@ class ImportResource extends Resource implements HasShieldPermissions
                         return trans_choice("{$lowercasedModelName}.resource.model_label", 1);
                     }),
                 TextColumn::make('file_name')
-                    ->label(__('import.file_name'))
+                    ->label(__('import.resource.file_name'))
                     ->searchable()
                     ->sortable(),
                 TextColumn::make('file_path')
-                    ->label(__('import.file_path'))
+                    ->label(__('import.resource.file_path'))
                     ->searchable()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('total_rows')
-                    ->label(__('import.total_rows'))
+                    ->label(__('import.resource.total_rows'))
                     ->numeric()
                     ->sortable(),
                 TextColumn::make('processed_rows')
-                    ->label(__('import.processed_rows'))
+                    ->label(__('import.resource.processed_rows'))
                     ->numeric()
                     ->sortable(),
                 TextColumn::make('successful_rows')
-                    ->label(__('import.successful_rows'))
+                    ->label(__('import.resource.successful_rows'))
                     ->numeric()
                     ->sortable(),
                 TextColumn::make('user.name')
-                    ->label(__('import.user'))
+                    ->label(__('import.resource.user'))
                     ->searchable()
                     ->sortable()
                     ->visible(static::canViewAll())
                     ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('creator.name')
+                    ->label(ucfirst(__('validation.attributes.creator')))
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true)
+                    ->visible(static::canViewAll()),
                 TextColumn::make('completed_at')
-                    ->label(__('import.completed_at'))
+                    ->label(__('import.resource.completed_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),

--- a/app/Filament/Resources/ImportResource.php
+++ b/app/Filament/Resources/ImportResource.php
@@ -34,7 +34,8 @@ class ImportResource extends Resource implements HasShieldPermissions
         $query = parent::getEloquentQuery();
 
         if (! static::canViewAll()) {
-            $query->where('user_id', Auth::id());
+            $query->where('user_id', Auth::id())
+                ->orWhere('creator_id', Auth::id());
         }
 
         return $query;

--- a/app/Models/Export.php
+++ b/app/Models/Export.php
@@ -2,12 +2,12 @@
 
 namespace App\Models;
 
+use App\Services\CreatorService;
 use Filament\Actions\Exports\Models\Export as FilamentExport;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
 
 /**
  * @property string $user_id
@@ -38,12 +38,12 @@ class Export extends FilamentExport
         parent::booted();
 
         static::creating(function (Export $export) {
-            /** @var ?string */
-            $creatorId = Auth::id();
-            if ($creatorId === null) {
-                return false;
+            // If creator_id is not already set, assign it.
+            // This prevents overriding a manually set ID (e.g., in tests).
+            // @phpstan-ignore-next-line
+            if (is_null($export->creator_id)) {
+                $export->creator_id = CreatorService::getCreatorOrFail()->id;
             }
-            $export->creator_id = $creatorId;
         });
 
         static::deleted(function (Export $export) {

--- a/app/Models/Export.php
+++ b/app/Models/Export.php
@@ -5,7 +5,9 @@ namespace App\Models;
 use Filament\Actions\Exports\Models\Export as FilamentExport;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @property string $user_id
@@ -19,6 +21,8 @@ use Illuminate\Support\Carbon;
  * @property ?Carbon $created_at
  * @property ?Carbon $updated_at
  * @property-read User $user
+ * @property string $creator_id
+ * @property-read User $creator
  *
  * @method static \Database\Factories\ExportFactory factory(...$parameters)
  */
@@ -33,6 +37,15 @@ class Export extends FilamentExport
     {
         parent::booted();
 
+        static::creating(function (Export $export) {
+            /** @var ?string */
+            $creatorId = Auth::id();
+            if ($creatorId === null) {
+                return false;
+            }
+            $export->creator_id = $creatorId;
+        });
+
         static::deleted(function (Export $export) {
             $disk = $export->getFileDisk();
             $directory = $export->getFileDirectory();
@@ -41,5 +54,13 @@ class Export extends FilamentExport
                 $disk->deleteDirectory($directory);
             }
         });
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'creator_id');
     }
 }

--- a/app/Models/Import.php
+++ b/app/Models/Import.php
@@ -2,12 +2,12 @@
 
 namespace App\Models;
 
+use App\Services\CreatorService;
 use Filament\Actions\Imports\Models\Import as FilamentImport;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
 
 /**
  * @property string $id
@@ -39,12 +39,12 @@ class Import extends FilamentImport
         parent::booted();
 
         static::creating(function (Import $import) {
-            /** @var ?string */
-            $creatorId = Auth::id();
-            if ($creatorId === null) {
-                return false;
+            // If creator_id is not already set, assign it.
+            // This prevents overriding a manually set ID (e.g., in tests).
+            // @phpstan-ignore-next-line
+            if (is_null($import->creator_id)) {
+                $import->creator_id = CreatorService::getCreatorOrFail()->id;
             }
-            $import->creator_id = $creatorId;
         });
     }
 

--- a/app/Models/Import.php
+++ b/app/Models/Import.php
@@ -5,7 +5,9 @@ namespace App\Models;
 use Filament\Actions\Imports\Models\Import as FilamentImport;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @property string $id
@@ -19,7 +21,8 @@ use Illuminate\Support\Carbon;
  * @property string $user_id
  * @property ?Carbon $created_at
  * @property ?Carbon $updated_at
- * @property-read User $user
+ * @property string $creator_id
+ * @property-read User $creator
  *
  * @method static \Database\Factories\ImportFactory factory(...$parameters)
  */
@@ -29,4 +32,26 @@ class Import extends FilamentImport
     use HasFactory;
 
     use HasUlids;
+
+    protected static function booted(): void
+    {
+        parent::booted();
+
+        static::creating(function (Import $import) {
+            /** @var ?string */
+            $creatorId = Auth::id();
+            if ($creatorId === null) {
+                return false;
+            }
+            $import->creator_id = $creatorId;
+        });
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'creator_id');
+    }
 }

--- a/app/Models/Import.php
+++ b/app/Models/Import.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Auth;
  * @property ?Carbon $updated_at
  * @property string $creator_id
  * @property-read User $creator
+ * @property-read User $user
  *
  * @method static \Database\Factories\ImportFactory factory(...$parameters)
  */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -50,6 +50,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property-read Collection<int, Role> $roles
  * @property-read ?int $roles_count
  * @property-read string $profile_photo_url
+ * @property-read Collection<int, Export> $exports
  *
  * @method static UserFactory factory($count = null, $state = [])
  * @method static Builder|User newModelQuery()
@@ -145,6 +146,14 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
         ])->save();
     }
 
+    /**
+     * @return HasMany<Export, $this>
+     */
+    public function exports(): HasMany
+    {
+        return $this->hasMany(Export::class, 'creator_id');
+    }
+
     public function getFilamentAvatarUrl(): ?string
     {
         if (Jetstream::managesProfilePhotos() && $this->profilePhotoMedia !== null) {
@@ -160,6 +169,9 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
 
     public function isReferenced(): bool
     {
+        if ($this->exports()->exists()) {
+            return true;
+        }
         if ($this->media()->exists()) {
             return true;
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -181,6 +181,9 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
         if ($this->exports()->exists()) {
             return true;
         }
+        if ($this->imports()->exists()) {
+            return true;
+        }
         if ($this->media()->exists()) {
             return true;
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -51,6 +51,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property-read ?int $roles_count
  * @property-read string $profile_photo_url
  * @property-read Collection<int, Export> $exports
+ * @property-read Collection<int, Import> $imports
  *
  * @method static UserFactory factory($count = null, $state = [])
  * @method static Builder|User newModelQuery()
@@ -144,6 +145,14 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
         $this->forceFill([
             'profile_photo_media_id' => null,
         ])->save();
+    }
+
+    /**
+     * @return HasMany<Import, $this>
+     */
+    public function imports(): HasMany
+    {
+        return $this->hasMany(Import::class, 'creator_id');
     }
 
     /**

--- a/app/Policies/ExportPolicy.php
+++ b/app/Policies/ExportPolicy.php
@@ -15,11 +15,11 @@ class ExportPolicy
      */
     public function view(User $user, Export $export): bool
     {
-        if ($user->isNot($export->user) && ! $this->viewAll($user)) {
-            return false;
+        if ($user->is($export->user) || $user->is($export->creator) || $this->viewAll($user)) {
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     /**
@@ -59,10 +59,10 @@ class ExportPolicy
      */
     public function delete(User $user, Export $export): bool
     {
-        if ($user->isNot($export->user) && ! $this->viewAll($user)) {
-            return false;
+        if ($user->is($export->user) || $user->is($export->creator) || $this->viewAll($user)) {
+            return true;
         }
 
-        return true;
+        return false;
     }
 }

--- a/app/Policies/ImportPolicy.php
+++ b/app/Policies/ImportPolicy.php
@@ -15,11 +15,11 @@ class ImportPolicy
      */
     public function view(User $user, Import $import): bool
     {
-        if ($user->isNot($import->user) && ! $this->viewAll($user)) {
-            return false;
+        if ($user->is($import->user) || $user->is($import->creator) || $this->viewAll($user)) {
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     /**
@@ -59,10 +59,10 @@ class ImportPolicy
      */
     public function delete(User $user, Import $import): bool
     {
-        if ($user->isNot($import->user) && ! $this->viewAll($user)) {
-            return false;
+        if ($user->is($import->user) || $user->is($import->creator) || $this->viewAll($user)) {
+            return true;
         }
 
-        return true;
+        return false;
     }
 }

--- a/app/Services/CreatorService.php
+++ b/app/Services/CreatorService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Support\Facades\Auth;
+use RuntimeException;
+
+class CreatorService
+{
+    /**
+     * The user who is acting as the creator for the current operation.
+     */
+    protected static ?User $creator = null;
+
+    /**
+     * Set the creator for a specific block of code.
+     * Ensures the creator is cleared afterwards to prevent state leakage.
+     *
+     * @return mixed
+     */
+    public static function withCreator(User $user, Closure $callback)
+    {
+        static::$creator = $user;
+
+        try {
+            // Execute the provided logic
+            return $callback();
+        } finally {
+            // Always clear the creator after the operation is complete
+            static::$creator = null;
+        }
+    }
+
+    /**
+     * Get the currently set creator.
+     */
+    public static function getCreator(): ?User
+    {
+        // Return the explicitly set creator, or fall back to the authenticated user.
+        return static::$creator ?? (Auth::user() instanceof User ? Auth::user() : null);
+    }
+
+    /**
+     * Get the currently set creator or fail if none is found.
+     * This is the method our models will use.
+     *
+     * @throws RuntimeException
+     */
+    public static function getCreatorOrFail(): User
+    {
+        $creator = self::getCreator();
+
+        if (! $creator) {
+            throw new RuntimeException(
+                'A creator could not be determined. Ensure the operation is run by an authenticated user or within a CreatorService::withCreator() block.'
+            );
+        }
+
+        return $creator;
+    }
+}

--- a/database/migrations/0001_01_01_000011_create_exports_table.php
+++ b/database/migrations/0001_01_01_000011_create_exports_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('exports', function (Blueprint $table) {
             $table->ulid('id')->primary();
+            $table->foreignUlid('creator_id')->constrained('users');
             $table->timestamp('completed_at')->nullable();
             $table->string('file_disk');
             $table->string('file_name')->nullable();

--- a/database/migrations/0001_01_01_000012_create_imports_table.php
+++ b/database/migrations/0001_01_01_000012_create_imports_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('imports', function (Blueprint $table) {
             $table->ulid('id')->primary();
+            $table->foreignUlid('creator_id')->constrained('users');
             $table->timestamp('completed_at')->nullable();
             $table->string('file_name');
             $table->string('file_path');

--- a/lang/en/export.php
+++ b/lang/en/export.php
@@ -1,13 +1,16 @@
 <?php
 
 return [
-    'exporter' => 'Exporter',
-    'file_name' => 'File Name',
-    'file_disk' => 'File Disk',
-    'total_rows' => 'Total Rows',
-    'processed_rows' => 'Processed Rows',
-    'successful_rows' => 'Successful Rows',
-    'initiated_by' => 'Initiated By',
-    'completed_at' => 'Completed At',
-    'download_name' => 'Download :name',
+    'resource' => [
+        'completed_at' => 'Completed At',
+        'download_name' => 'Download :name',
+        'exporter' => 'Exporter',
+        'file_disk' => 'File Disk',
+        'file_name' => 'File Name',
+        'model_label' => 'Export|Exports',
+        'processed_rows' => 'Processed Rows',
+        'successful_rows' => 'Successful Rows',
+        'total_rows' => 'Total Rows',
+        'user' => 'User',
+    ],
 ];

--- a/lang/en/import.php
+++ b/lang/en/import.php
@@ -1,13 +1,16 @@
 <?php
 
 return [
-    'file_name' => 'File Name',
-    'importer' => 'Importer',
-    'total_rows' => 'Total Rows',
-    'processed_rows' => 'Processed Rows',
-    'user' => 'User',
-    'failed_imports' => 'Failed Imports',
-    'file_path' => 'File Path',
-    'successful_rows' => 'Successful Rows',
-    'completed_at' => 'Completed At',
+    'resource' => [
+        'completed_at' => 'Completed At',
+        'failed_imports' => 'Failed Imports',
+        'file_name' => 'File Name',
+        'file_path' => 'File Path',
+        'importer' => 'Importer',
+        'model_label' => 'Import|Imports',
+        'processed_rows' => 'Processed Rows',
+        'successful_rows' => 'Successful Rows',
+        'total_rows' => 'Total Rows',
+        'user' => 'User',
+    ],
 ];

--- a/lang/id/export.php
+++ b/lang/id/export.php
@@ -1,13 +1,16 @@
 <?php
 
 return [
-    'exporter' => 'Eksportir',
-    'file_name' => 'Nama File',
-    'file_disk' => 'Disk File',
-    'total_rows' => 'Jumlah Baris',
-    'processed_rows' => 'Baris yang Diproses',
-    'successful_rows' => 'Baris yang Berhasil',
-    'initiated_by' => 'Diprakarsai Oleh',
-    'completed_at' => 'Selesai Pada',
-    'download_name' => 'Unduh :name',
+    'resource' => [
+        'completed_at' => 'Selesai Pada',
+        'download_name' => 'Unduh :name',
+        'exporter' => 'Pengekspor',
+        'file_disk' => 'Disk Berkas',
+        'file_name' => 'Nama Berkas',
+        'model_label' => 'Ekspor|Ekspor',
+        'processed_rows' => 'Baris yang Diproses',
+        'successful_rows' => 'Baris yang Berhasil',
+        'total_rows' => 'Jumlah Baris',
+        'user' => 'Pengguna',
+    ],
 ];

--- a/lang/id/import.php
+++ b/lang/id/import.php
@@ -1,13 +1,16 @@
 <?php
 
 return [
-    'file_name' => 'Nama Berkas',
-    'importer' => 'Pengimpor',
-    'total_rows' => 'Total Baris',
-    'processed_rows' => 'Baris Diproses',
-    'user' => 'Pengguna',
-    'failed_imports' => 'Impor Gagal',
-    'file_path' => 'Jalur Berkas',
-    'successful_rows' => 'Baris Berhasil',
-    'completed_at' => 'Selesai Pada',
+    'resource' => [
+        'completed_at' => 'Selesai Pada',
+        'failed_imports' => 'Impor Gagal',
+        'file_name' => 'Nama Berkas',
+        'file_path' => 'Jalur Berkas',
+        'importer' => 'Pengimpor',
+        'model_label' => 'Impor|Impor',
+        'processed_rows' => 'Baris Diproses',
+        'successful_rows' => 'Baris Berhasil',
+        'total_rows' => 'Total Baris',
+        'user' => 'Pengguna',
+    ],
 ];

--- a/tests/Feature/Models/ExportTest.php
+++ b/tests/Feature/Models/ExportTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Models;
 
 use App\Models\Export;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
@@ -19,6 +20,10 @@ class ExportTest extends TestCase
 
     public function test_deletes_directory_on_export_deletion_void(): void
     {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
         // Create a real Export model instance.
         // We need to save it to the database for the 'deleted' event to fire correctly
         // when we call $export->delete().
@@ -43,6 +48,10 @@ class ExportTest extends TestCase
 
     public function test_does_not_delete_directory_if_not_exists_void(): void
     {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
         // Create a real Export model instance
         $export = Export::factory()->create([
             'file_disk' => 'public',
@@ -59,5 +68,22 @@ class ExportTest extends TestCase
 
         // Assert: The directory should still not exist (no change, no error)
         $this->assertFalse(Storage::disk('public')->exists($directoryPath), "The directory {$directoryPath} should be missing.");
+    }
+
+    public function test_creator_id_is_set_on_creation(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $export = Export::factory()->create();
+
+        $this->assertEquals($user->id, $export->creator_id);
+    }
+
+    public function test_create_export_throws_exception_when_not_authenticated(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        Export::factory()->create();
     }
 }

--- a/tests/Feature/Models/ImportTest.php
+++ b/tests/Feature/Models/ImportTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Models\Import;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creator_id_is_set_on_creation(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $import = Import::factory()->create();
+
+        $this->assertEquals($user->id, $import->creator_id);
+    }
+
+    public function test_create_import_throws_exception_when_not_authenticated(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        Import::factory()->create();
+    }
+}


### PR DESCRIPTION
This pull request introduces creator tracking for exports and imports, enhancing access control and improving the user experience.

Key changes include:

- Adding `creator_id` to the `exports` and `imports` tables to track the user who initiated the processes.
- Implementing `CreatorService` to reliably determine and manage the creator, particularly in background jobs.
- Adjusting import and export policies to allow the creator to view, update, and delete their own resources.
- Improving resource labels and columns in Filament for better clarity and localization.
- Updating the ExportResource and ImportResource queries to filter by both `user_id` and `creator_id`, ensuring correct ownership checks.
- Adding tests to verify the functionality of `creator_id` and authentication requirements.
- Fixing a bug in the `user` model to check for the existence of the `imports()` relationship.
- Updating ExportResourceTest to properly filter by creator_id.