### PR TITLE
feat: enhance error pages and introduce mail components

### DIFF
--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,5 @@
+@extends('errors.minimal')
+
+@section('title', __('Not Found'))
+@section('code', '404')
+@section('message', __('Not Found'))

--- a/resources/views/errors/4xx.blade.php
+++ b/resources/views/errors/4xx.blade.php
@@ -1,0 +1,1 @@
+@include('errors.common')

--- a/resources/views/errors/5xx.blade.php
+++ b/resources/views/errors/5xx.blade.php
@@ -1,0 +1,1 @@
+@include('errors.common')

--- a/resources/views/errors/common.blade.php
+++ b/resources/views/errors/common.blade.php
@@ -1,0 +1,21 @@
+@extends('errors.minimal')
+
+@php
+    $exceptionMessage = isset($exception) ? ($exception->getMessage() ?: __('Server Error')) : __('Server Error');
+@endphp
+
+@section('title')
+    {{ $exceptionMessage }}
+@endsection
+
+@section('code')
+    @isset($exception)
+        {{ $exception->getStatusCode() }}
+    @else
+        {{ __('Server Error') }}
+    @endisset
+@endsection
+
+@section('message')
+    {{ $exceptionMessage }}
+@endsection

--- a/resources/views/errors/common.blade.php
+++ b/resources/views/errors/common.blade.php
@@ -1,7 +1,9 @@
 @extends('errors.minimal')
 
 @php
-    $exceptionMessage = isset($exception) ? ($exception->getMessage() ?: __('Server Error')) : __('Server Error');
+    $defaultMessage = __('Server Error');
+    $exceptionMessage =
+        config('app.debug') && isset($exception) ? ($exception->getMessage() ?: $defaultMessage) : $defaultMessage;
 @endphp
 
 @section('title')

--- a/resources/views/errors/minimal.blade.php
+++ b/resources/views/errors/minimal.blade.php
@@ -1,0 +1,20 @@
+<x-layouts.app>
+    <x-container>
+        <div class="flex flex-col items-center justify-center min-h-[50vh]">
+            <div class="flex items-center pt-8 sm:justify-start sm:pt-0">
+                <div class="px-4 text-4xl font-bold tracking-wider border-r border-gray-400">
+                    @yield('code')
+                </div>
+
+                <div class="ml-4 text-lg tracking-wider text-gray-500 uppercase">
+                    @yield('message')
+                </div>
+            </div>
+            <div class="mt-8">
+                <x-filament::button :href="route('home')" tag="a" wire:navigate icon="heroicon-o-home">
+                    <span>{{ __('navigation-menu.menu.home') }}</span>
+                </x-filament::button>
+            </div>
+        </div>
+    </x-container>
+</x-layouts.app>

--- a/resources/views/vendor/mail/html/button.blade.php
+++ b/resources/views/vendor/mail/html/button.blade.php
@@ -2,6 +2,8 @@
 
 @php
     use Filament\Support\Facades\FilamentColor;
+    $colors = FilamentColor::getColors();
+    $buttonColor = array_key_exists($color, $colors) ? $colors[$color][500] : $colors['primary'][500];
 @endphp
 
 <table class="action" align="{{ $align }}" width="100%" cellpadding="0" cellspacing="0" role="presentation">
@@ -13,7 +15,7 @@
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation">
                             <tr>
                                 <td
-                                    style="border-radius: 8px; background-color: rgb({{ FilamentColor::getColors()[$color][500] }}); padding: 0.5rem 0.75rem;">
+                                    style="border-radius: 8px; background-color: rgb({{ $buttonColor }}); padding: 0.5rem 0.75rem;">
                                     <a href="{{ $url }}" class="button" target="_blank" rel="noopener"
                                         style="background-color: transparent; display: inline-block;">{!! $slot !!}</a>
                                 </td>

--- a/resources/views/vendor/mail/html/button.blade.php
+++ b/resources/views/vendor/mail/html/button.blade.php
@@ -1,0 +1,27 @@
+@props(['url', 'color' => 'primary', 'align' => 'center'])
+
+@php
+    use Filament\Support\Facades\FilamentColor;
+@endphp
+
+<table class="action" align="{{ $align }}" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td align="{{ $align }}">
+            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                <tr>
+                    <td align="{{ $align }}">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation">
+                            <tr>
+                                <td
+                                    style="border-radius: 8px; background-color: rgb({{ FilamentColor::getColors()[$color][500] }}); padding: 0.5rem 0.75rem;">
+                                    <a href="{{ $url }}" class="button" target="_blank" rel="noopener"
+                                        style="background-color: transparent; display: inline-block;">{!! $slot !!}</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -1,0 +1,34 @@
+@php
+    use Filament\Support\Facades\FilamentColor;
+@endphp
+
+<x-mail::layout>
+    {{-- Header --}}
+    <x-slot:header>
+        <x-mail::header :url="config('app.url')">
+            <span
+                style="font-size: 2.25rem; font-weight: 700; color:rgb({{ FilamentColor::getColors()['primary'][500] }})">
+                {{ config('app.name') }}
+            </span>
+        </x-mail::header>
+    </x-slot:header>
+
+    {{-- Body --}}
+    {!! $slot !!}
+
+    {{-- Subcopy --}}
+    @isset($subcopy)
+        <x-slot:subcopy>
+            <x-mail::subcopy>
+                {!! $subcopy !!}
+            </x-mail::subcopy>
+        </x-slot:subcopy>
+    @endisset
+
+    {{-- Footer --}}
+    <x-slot:footer>
+        <x-mail::footer>
+            © {{ date('Y') }} {{ config('app.name') }}. {{ __('All rights reserved.') }}
+        </x-mail::footer>
+    </x-slot:footer>
+</x-mail::layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,3 +32,7 @@ if (Jetstream::hasTermsAndPrivacyPolicyFeature()) {
 }
 
 Route::get('/sitemap.xml', [SitemapController::class, 'index']);
+
+Route::fallback(function () {
+    return response()->view('errors.404', [], 404);
+});

--- a/tests/Feature/Errors/PageNotFoundTest.php
+++ b/tests/Feature/Errors/PageNotFoundTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature\Errors;
+
+use Tests\TestCase;
+
+class PageNotFoundTest extends TestCase
+{
+    public function test_returns_a_404_error_page_for_an_unknown_route(): void
+    {
+        $response = $this->get('/a-route-that-does-not-exist');
+
+        $response->assertNotFound();
+        $response->assertSee(__('Not Found'));
+    }
+}


### PR DESCRIPTION
This pull request introduces several enhancements to error handling and adds new mail components for improved email rendering.

Key changes include:

- Implementation of a custom 404 error page and a foundational error layout for better user experience on invalid routes.
- Introduction of a common error view (`resources/views/errors/common.blade.php`) to consolidate error display logic for 4xx and 5xx errors, ensuring consistency.
- Addition of new Blade components (`button.blade.php` and `message.blade.php`) for rendering HTML emails, leveraging Filament's theming for buttons and overall email structure.
- Enhancement of error pages to prevent information leakage by only displaying detailed exception messages when `APP_DEBUG` is enabled, defaulting to a generic message in production.
- A fix to prevent fatal errors when an invalid color is passed to the mail button component, ensuring graceful fallback to the primary color.
- A new feature test to verify the correct display and functionality of the 404 error page.