### PR TITLE
refactor: refactor styling and class usage

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -1,6 +1,6 @@
 <nav x-data="navigationMenu" x-on:scroll.window.throttle.100ms="scroll"
     :class="{
-        '-translate-y-0': show,
+        '': show,
         '-translate-y-full': !show
     }"
     class="sticky top-0 left-0 z-20 w-full duration-500 bg-white transition-top dark:bg-gray-900 dark:border-gray-950/5">
@@ -57,7 +57,7 @@
 
     <!-- Drawer Overlay -->
     <div :class="{
-        '-translate-x-0': open,
+        '': open,
         '-translate-x-full': !open
     }"
         class="fixed left-0 z-30 w-full h-screen p-4 overflow-y-auto -translate-x-full bg-gray-950/50 dark:bg-gray-950/75 top-16">
@@ -65,7 +65,7 @@
 
     <!-- Drawer -->
     <div :class="{
-        '-translate-x-0': open,
+        '': open,
         '-translate-x-full': !open
     }"
         class="fixed left-0 z-40 w-64 h-screen p-4 overflow-y-auto transition-transform -translate-x-full bg-white top-16 dark:bg-gray-900"

--- a/resources/views/vendor/mail/html/button.blade.php
+++ b/resources/views/vendor/mail/html/button.blade.php
@@ -15,9 +15,9 @@
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation">
                             <tr>
                                 <td
-                                    style="border-radius: 8px; background-color: rgb({{ $buttonColor }}); padding: 0.5rem 0.75rem;">
-                                    <a href="{{ $url }}" class="button" target="_blank" rel="noopener"
-                                        style="background-color: transparent; display: inline-block;">{!! $slot !!}</a>
+                                    style="background-color: rgb({{ $buttonColor }}); border-radius: 8px; padding: 0.5rem 0.75rem;">
+                                    <a href="{{ $url }}" target="_blank" rel="noopener"
+                                        style="color: #fff; overflow: hidden; text-decoration: none;">{!! $slot !!}</a>
                                 </td>
                             </tr>
                         </table>


### PR DESCRIPTION
The `-translate-y-0` and `-translate-x-0` classes were removed as they are redundant, representing zero translation. This change simplifies Tailwind CSS class binding logic, making the intent clearer and relying on default positioning behavior when elements should occupy their natural, untranslated positions.

Additionally, the class attribute for the button link within the email template was removed. Direct inline styles were applied to ensure the button text color is white, handle potential text overflow, and remove default link underlines, improving visual consistency across different email clients.