### PR TITLE
feat: enforce media creator ownership and enable automatic file relocation

### DIFF
--- a/app/Filament/Resources/MediaResource.php
+++ b/app/Filament/Resources/MediaResource.php
@@ -47,6 +47,7 @@ class MediaResource extends CuratorMediaResource implements HasShieldPermissions
         return [
             ...parent::getPages(),
             'index' => Pages\ListMedia::route('/'),
+            'edit' => Pages\EditMedia::route('/{record}/edit'),
         ];
     }
 

--- a/app/Filament/Resources/MediaResource.php
+++ b/app/Filament/Resources/MediaResource.php
@@ -65,15 +65,18 @@ class MediaResource extends CuratorMediaResource implements HasShieldPermissions
      */
     public static function getAdditionalInformationFormSchema(): array
     {
-        // @phpstan-ignore-next-line
+        /** @var array<Forms\Components\Component> */
+        $parentComponents = parent::getAdditionalInformationFormSchema();
+
         return [
-            ...parent::getAdditionalInformationFormSchema(),
+            ...$parentComponents,
             static::canViewAll() ? Forms\Components\Select::make('creator_id')
                 ->label(__('attributes.created_by'))
                 ->relationship('creator', titleAttribute: 'name')
                 ->default(User::auth()?->id)
                 ->native(false)
-                ->searchable() : Forms\Components\Hidden::make('creator_id')
+                ->searchable()
+                ->required() : Forms\Components\Hidden::make('creator_id')
                 ->dehydrateStateUsing(fn () => User::auth()?->id),
         ];
     }

--- a/app/Filament/Resources/MediaResource/Pages/EditMedia.php
+++ b/app/Filament/Resources/MediaResource/Pages/EditMedia.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Filament\Resources\MediaResource\Pages;
+
+use App\Filament\Resources\MediaResource;
+use App\Models\Media;
+use Awcodes\Curator\Resources\MediaResource\EditMedia as BaseEditMedia;
+use Exception;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+
+class EditMedia extends BaseEditMedia
+{
+    protected static string $resource = MediaResource::class;
+
+    /**
+     * @return array<Action|ActionGroup>
+     *
+     * @throws Exception
+     */
+    public function getHeaderActions(): array
+    {
+        // Get the original header actions defined in the parent (Curator's) EditMedia page.
+        $actions = parent::getHeaderActions();
+
+        // Iterate through the actions to find and modify the 'preview' action.
+        /** @var array<Action|ActionGroup> */
+        $updatedActions = collect($actions)->map(function (Action|ActionGroup $action): Action|ActionGroup {
+            // Check if the current action is the 'preview' action.
+            if ($action instanceof Action && $action->getName() === 'preview') { // Check if it's an Action before getName()
+                // Override its URL definition.
+                // By providing a closure, the URL will be dynamically evaluated
+                // when the button is clicked, using the current state of $this->record.
+                return $action->url(function () {
+                    /** @var Media */
+                    $record = $this->record;
+
+                    return $record->url;
+                }, shouldOpenInNewTab: true);
+            }
+
+            // Return other actions as they are.
+            return $action;
+        })->toArray(); // Convert the collection back to an array.
+
+        return $updatedActions;
+    }
+}

--- a/app/Filament/Resources/MediaResource/Pages/EditMedia.php
+++ b/app/Filament/Resources/MediaResource/Pages/EditMedia.php
@@ -4,12 +4,12 @@ namespace App\Filament\Resources\MediaResource\Pages;
 
 use App\Filament\Resources\MediaResource;
 use App\Models\Media;
-use Awcodes\Curator\Resources\MediaResource\EditMedia as BaseEditMedia;
+use Awcodes\Curator\Resources\MediaResource\EditMedia as CuratorEditMedia;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 
-class EditMedia extends BaseEditMedia
+class EditMedia extends CuratorEditMedia
 {
     protected static string $resource = MediaResource::class;
 

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Gate;
  * @property string $id
  * @property string $disk
  * @property string $path
- * @property string|null $creator_id
+ * @property string $creator_id
  * @property User $creator
  * @property string $directory
  * @property string $visibility

--- a/app/Observers/MediaObserver.php
+++ b/app/Observers/MediaObserver.php
@@ -26,7 +26,7 @@ class MediaObserver extends CuratorMediaObserver
      */
     public function creating(CuratorMedia $media): void
     {
-        if ($media instanceof Media && $media->creator === null) {
+        if ($media instanceof Media && $media->creator === null && Auth::check()) {
             $media->creator()->associate(Auth::user());
         }
         parent::creating($media);

--- a/app/Observers/MediaObserver.php
+++ b/app/Observers/MediaObserver.php
@@ -5,6 +5,7 @@ namespace App\Observers;
 use App\Models\Media;
 use Awcodes\Curator\Models\Media as CuratorMedia;
 use Awcodes\Curator\Observers\MediaObserver as CuratorMediaObserver;
+use Awcodes\Curator\PathGenerators\UserPathGenerator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -38,6 +39,61 @@ class MediaObserver extends CuratorMediaObserver
     {
         $this->removeExif($media);
         $this->convertToWebP($media);
+    }
+
+    /**
+     * Handle the Media "updated" event.
+     */
+    public function updated(Media $media): void
+    {
+        // Get the configured path generator class
+        $pathGeneratorClass = config('curator.path_generator');
+
+        // Only apply this file moving logic if creator_id is dirty AND UserPathGenerator is in use
+        if ($media->isDirty('creator_id') && $pathGeneratorClass === UserPathGenerator::class) {
+            $newCreatorId = $media->creator_id;
+
+            /** @var string $oldFullPath */
+            $oldFullPath = $media->getOriginal('path');
+            $filename = pathinfo($oldFullPath, PATHINFO_BASENAME);
+
+            // Determine the new creator folder (e.g., '1' or 'guest')
+            $newCreatorFolder = $newCreatorId ? (string) $newCreatorId : 'guest';
+
+            // Get the base directory from Curator's config, defaulting to 'media'
+            $baseDirectoryConfig = config('curator.directory', 'media');
+
+            // Ensure $baseDirectoryConfig is a string
+            if (! is_string($baseDirectoryConfig)) {
+                Log::warning('Curator directory config is not a string. Defaulting to "media".', ['config_value' => $baseDirectoryConfig]);
+                $baseDirectoryConfig = 'media';
+            }
+
+            // Construct the new base directory (e.g., 'media/1' or 'media/guest')
+            $newBaseDirectory = "{$baseDirectoryConfig}/{$newCreatorFolder}";
+
+            // Construct the new full path (e.g., 'media/1/filename.ext')
+            $newFullPath = "{$newBaseDirectory}/{$filename}";
+
+            // Ensure the new directory exists
+            Storage::disk($media->disk)->makeDirectory($newBaseDirectory);
+
+            // Move the file only if the old path exists and the old and new paths are different
+            if ($oldFullPath && Storage::disk($media->disk)->exists($oldFullPath) && $oldFullPath !== $newFullPath) {
+                Storage::disk($media->disk)->move($oldFullPath, $newFullPath);
+
+                // Update the media model's path and directory attributes
+                $media->path = $newFullPath;
+                $media->directory = $newBaseDirectory;
+
+                // Save the model quietly to prevent re-triggering the observer
+                $media->saveQuietly();
+            } elseif ($oldFullPath && ! Storage::disk($media->disk)->exists($oldFullPath)) {
+                Log::warning("File not found at old path: {$oldFullPath} for media ID: {$media->id}");
+            }
+        }
+        // If the path generator is not UserPathGenerator, or creator_id is not dirty,
+        // this custom file moving logic is skipped.
     }
 
     private function convertToWebP(Media $media): void

--- a/app/Observers/MediaObserver.php
+++ b/app/Observers/MediaObserver.php
@@ -6,6 +6,7 @@ use App\Models\Media;
 use Awcodes\Curator\Models\Media as CuratorMedia;
 use Awcodes\Curator\Observers\MediaObserver as CuratorMediaObserver;
 use Awcodes\Curator\PathGenerators\UserPathGenerator;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -26,8 +27,14 @@ class MediaObserver extends CuratorMediaObserver
      */
     public function creating(CuratorMedia $media): void
     {
-        if ($media instanceof Media && $media->creator === null && Auth::check()) {
-            $media->creator()->associate(Auth::user());
+        if ($media instanceof Media && $media->creator === null) {
+            if (Auth::check()) {
+                $media->creator()->associate(Auth::user());
+            } else {
+                throw new AuthenticationException(
+                    'Cannot create Media without an authenticated user to assign as the creator.'
+                );
+            }
         }
         parent::creating($media);
     }

--- a/database/factories/MediaFactory.php
+++ b/database/factories/MediaFactory.php
@@ -33,8 +33,8 @@ class MediaFactory extends Factory
             'title' => $this->faker->optional()->sentence,
             'description' => $this->faker->optional()->paragraph,
             'caption' => $this->faker->optional()->paragraph,
-            'exif' => $this->faker->optional()->paragraph,
-            'curations' => $this->faker->optional()->paragraph,
+            'exif' => [],
+            'curations' => [],
         ];
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/tests/Feature/Filament/MediaResource/Pages/EditMediaTest.php
+++ b/tests/Feature/Filament/MediaResource/Pages/EditMediaTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature\Filament\MediaResource\Pages;
+
+use App\Filament\Resources\MediaResource\Pages\EditMedia;
+use App\Models\Media; // Assuming Media model exists
+use App\Models\User;
+use Filament\Actions\Action;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase; // Assuming a base TestCase
+
+class EditMediaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_preview_action_url_is_correct(): void
+    {
+        $media = Media::factory()->create([
+            'name' => 'test',
+            'disk' => 'public',
+            'directory' => 'media',
+            'ext' => 'jpg',
+            'path' => 'test.jpg',
+            'creator_id' => $this->user->id,
+        ]);
+
+        // Test the Livewire component directly
+        $component = Livewire::test(EditMedia::class, ['record' => $media->getRouteKey()]);
+        $component->assertSuccessful();
+
+        // Retrieve the actions from the Livewire component instance
+        /** @var EditMedia */
+        $instance = $component->instance();
+        $actions = $instance->getHeaderActions();
+
+        $previewAction = null;
+        foreach ($actions as $action) {
+            if ($action instanceof Action && $action->getName() === 'preview') {
+                $previewAction = $action;
+                break;
+            }
+        }
+
+        $this->assertNotNull($previewAction, 'Preview action not found.');
+        $this->assertEquals($media->url, $previewAction->getUrl(), 'Preview action URL does not match media URL.');
+    }
+
+    public function test_other_actions_are_unchanged(): void
+    {
+        // Create a media record
+        $media = Media::factory()->create([
+            'name' => 'test',
+            'disk' => 'public',
+            'directory' => 'media',
+            'ext' => 'jpg',
+            'path' => 'test.jpg',
+            'creator_id' => $this->user->id,
+        ]);
+
+        // Get the actions from the Livewire component
+        $component = Livewire::test(EditMedia::class, ['record' => $media->getRouteKey()]);
+        $component->assertSuccessful();
+
+        /** @var EditMedia */
+        $instance = $component->instance();
+        $actions = $instance->getHeaderActions();
+
+        $foundOtherAction = false;
+        foreach ($actions as $action) {
+            // Assuming there\'s a \'delete\' action by default in Filament\'s Edit page
+            if ($action instanceof Action && $action->getName() === 'delete') {
+                $foundOtherAction = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($foundOtherAction, 'Other actions (e.g., delete) were not found, indicating they might have been removed or altered.');
+    }
+}

--- a/tests/Feature/Filament/Resources/MediaResourceTest.php
+++ b/tests/Feature/Filament/Resources/MediaResourceTest.php
@@ -6,7 +6,10 @@ use App\Filament\Resources\MediaResource;
 use App\Models\Media;
 use App\Models\Permission;
 use App\Models\User;
+use Awcodes\Curator\Resources\MediaResource\CreateMedia;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class MediaResourceTest extends TestCase
@@ -58,5 +61,26 @@ class MediaResourceTest extends TestCase
         $this->get(MediaResource::getUrl('index'))
             ->assertSee($media->pretty_name)
             ->assertSee($media->size_for_humans);
+    }
+
+    public function test_creator_id_is_required_when_view_all_permission_is_granted(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // Assign 'view_all_media' permission to the user
+        Permission::firstOrCreate(['name' => 'view_all_media']);
+        $user->givePermissionTo('view_all_media');
+
+        // Assuming 'name' and 'file' are required fields for Media creation
+        // and that 'creator_id' is the only field we are intentionally null for validation.
+        $livewire = Livewire::test(CreateMedia::class);
+        $livewire->fillForm([
+            'name' => 'Test Media Name',
+            'file' => UploadedFile::fake()->image('test_image.jpg'),
+            'creator_id' => null,
+        ]);
+        $livewire->call('create');
+        $livewire->assertHasErrors(['data.creator_id']);
     }
 }

--- a/tests/Unit/Observers/MediaObserverTest.php
+++ b/tests/Unit/Observers/MediaObserverTest.php
@@ -300,15 +300,19 @@ class MediaObserverTest extends TestCase
         ]);
     }
 
-    public function test_does_not_assign_creator_when_no_user_is_authenticated(): void
+    public function test_throws_exception_when_creating_media_without_authentication(): void
     {
         // 1. Arrange
-        // Ensure no user is authenticated for this test
+        // Ensure no user is authenticated for this test.
         Auth::logout();
 
-        $this->expectException(\Exception::class);
+        // 2. Assert
+        $this->expectException(\Illuminate\Auth\AuthenticationException::class);
+        $this->expectExceptionMessage(
+            'Cannot create Media without an authenticated user to assign as the creator.'
+        );
 
-        // 2. Act
+        // 3. Act
         Media::factory()->create([
             'creator_id' => null,
         ]);

--- a/tests/Unit/Observers/MediaObserverTest.php
+++ b/tests/Unit/Observers/MediaObserverTest.php
@@ -260,4 +260,23 @@ class MediaObserverTest extends TestCase
             throw $e; // Re-throw the exception to satisfy expectException
         }
     }
+
+    public function test_assigns_authenticated_user_as_creator_when_creating_media_without_one(): void
+    {
+        // 1. Arrange
+        $user = User::factory()->create();
+        $this->actingAs($user); // Authenticate the user
+
+        // 2. Act
+        // The factory will trigger the 'creating' event
+        $media = Media::factory()->create([
+            'creator_id' => null, // Explicitly create without a creator
+        ]);
+
+        // 3. Assert
+        $this->assertDatabaseHas('media', [
+            'id' => $media->id,
+            'creator_id' => $user->id,
+        ]);
+    }
 }

--- a/tests/Unit/Observers/MediaObserverTest.php
+++ b/tests/Unit/Observers/MediaObserverTest.php
@@ -5,8 +5,11 @@ namespace Tests\Unit\Observers;
 use App\Models\Media;
 use App\Models\User;
 use Awcodes\Curator\PathGenerators\UserPathGenerator;
+use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Mockery;
 use Tests\TestCase;
 
 class MediaObserverTest extends TestCase
@@ -64,5 +67,197 @@ class MediaObserverTest extends TestCase
             'directory' => $newDir,
             'creator_id' => $user2->id,
         ]);
+    }
+
+    public function test_does_not_move_file_when_creator_id_is_unchanged(): void
+    {
+        // 1. Arrange
+        $user = User::factory()->create();
+
+        $originalDir = 'media/'.$user->id;
+        $filename = 'test-image.jpg';
+        $originalPath = $originalDir.'/'.$filename;
+        Storage::disk('public')->put($originalPath, 'dummy content');
+
+        $media = Media::factory()->create([
+            'creator_id' => $user->id,
+            'disk' => 'public',
+            'directory' => $originalDir,
+            'path' => $originalPath,
+        ]);
+
+        // 2. Act
+        // Update a different attribute, creator_id remains unchanged
+        $media->title = 'New Title';
+        $media->save();
+
+        // 3. Assert
+        // Assert the file still exists in the original location
+        $this->assertTrue(Storage::disk('public')->exists($originalPath));
+        // Assert the database record's path and directory are unchanged
+        $this->assertDatabaseHas('media', [
+            'id' => $media->id,
+            'path' => $originalPath,
+            'directory' => $originalDir,
+            'creator_id' => $user->id,
+            'title' => 'New Title',
+        ]);
+    }
+
+    public function test_does_not_move_file_when_path_generator_is_not_user_path_generator(): void
+    {
+        // 1. Arrange
+        // Set a different path generator
+        config(['curator.path_generator' => \Awcodes\Curator\PathGenerators\DatePathGenerator::class]);
+
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $originalDir = 'media/'.$user1->id;
+        $filename = 'test-image.jpg';
+        $originalPath = $originalDir.'/'.$filename;
+        Storage::disk('public')->put($originalPath, 'dummy content');
+
+        $media = Media::factory()->create([
+            'creator_id' => $user1->id,
+            'disk' => 'public',
+            'directory' => $originalDir,
+            'path' => $originalPath,
+        ]);
+
+        // 2. Act
+        $media->creator_id = $user2->id;
+        $media->save();
+
+        // 3. Assert
+        // Assert the file still exists in the original location
+        $this->assertTrue(Storage::disk('public')->exists($originalPath));
+        // Assert the database record's path and directory are unchanged, but creator_id is updated
+        $this->assertDatabaseHas('media', [
+            'id' => $media->id,
+            'path' => $originalPath,
+            'directory' => $originalDir,
+            'creator_id' => $user2->id, // creator_id should still be updated in DB
+        ]);
+    }
+
+    public function test_does_not_move_file_and_logs_warning_when_source_file_does_not_exist(): void
+    {
+        // 1. Arrange
+        Log::shouldReceive('warning')
+            ->once()
+            ->with(Mockery::pattern('/^MediaObserver: Source file not found at/'));
+
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $originalDir = 'media/'.$user1->id;
+        $filename = 'test-image.jpg';
+        $originalPath = $originalDir.'/'.$filename;
+        // DO NOT put the file in storage, simulate it missing
+
+        $media = Media::factory()->create([
+            'creator_id' => $user1->id,
+            'disk' => 'public',
+            'directory' => $originalDir,
+            'path' => $originalPath,
+        ]);
+
+        // 2. Act
+        $media->creator_id = $user2->id;
+        $media->save();
+
+        // 3. Assert
+        // Assert that no file was moved (since it didn't exist)
+        $this->assertFalse(Storage::disk('public')->exists($originalPath));
+        $newDir = 'media/'.$user2->id;
+        $newPath = $newDir.'/'.$filename;
+        $this->assertFalse(Storage::disk('public')->exists($newPath));
+
+        // Assert the database record's path and directory are unchanged, but creator_id is updated
+        $this->assertDatabaseHas('media', [
+            'id' => $media->id,
+            'path' => $originalPath, // Path should remain the old one in DB
+            'directory' => $originalDir, // Directory should remain the old one in DB
+            'creator_id' => $user2->id, // creator_id should still be updated in DB
+        ]);
+    }
+
+    public function test_rolls_back_transaction_when_file_move_fails(): void
+    {
+        // 1. Arrange
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $originalDir = 'media/'.$user1->id;
+        $filename = 'test-image.jpg';
+        $originalPath = $originalDir.'/'.$filename;
+        Storage::disk('public')->put($originalPath, 'dummy content');
+
+        $media = Media::factory()->create([
+            'creator_id' => $user1->id,
+            'disk' => 'public',
+            'directory' => $originalDir,
+            'path' => $originalPath,
+        ]);
+
+        $newDir = 'media/'.$user2->id;
+        $newPath = $newDir.'/'.$filename;
+
+        // Mock the Storage facade
+        $mockDisk = Mockery::mock(Filesystem::class);
+
+        // Expect the 'disk' method to be called on Storage, returning our mockDisk
+        Storage::shouldReceive('disk')
+            ->with('public') // Assuming 'public' disk is used
+            ->andReturn($mockDisk);
+
+        // Allow makeDirectory to be called on the mock disk
+        /** @var \Mockery\ExpectationInterface $expectation */
+        $expectation = $mockDisk->shouldReceive('makeDirectory');
+        $expectation->andReturn(true);
+
+        // On our mockDisk, expect 'move' to be called and throw an exception
+        /** @var \Mockery\Expectation $expectationMove */
+        $expectationMove = $mockDisk->shouldReceive('move');
+        $higherOrderMessage = $expectationMove->once();
+        $higherOrderMessage->andThrow(new \Exception('Simulated file move failure'));
+
+        // Also, on our mockDisk, expect 'exists' to be called and return true for the original path
+        // and false for the new path (after rollback)
+        /** @var \Mockery\Expectation $expectationExists */
+        $expectationExists = $mockDisk->shouldReceive('exists');
+        $withExpectation = $expectationExists->with($originalPath);
+        $withExpectation->andReturn(true);
+
+        /** @var \Mockery\Expectation $expectationExists2 */
+        $expectationExists2 = $mockDisk->shouldReceive('exists');
+        $withExpectation2 = $expectationExists2->with($newPath);
+        $withExpectation2->andReturn(false);
+
+        // 2. Act & Assert
+        // Expect an exception to be thrown
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Simulated file move failure');
+
+        try {
+            $media->creator_id = $user2->id;
+            $media->save();
+        } catch (\Exception $e) {
+            // Assert that the original file still exists (transaction rolled back)
+            $this->assertTrue(Storage::disk('public')->exists($originalPath));
+            $media->refresh();
+            // Assert that the new file does not exist
+            $this->assertFalse(Storage::disk('public')->exists($newPath));
+
+            // Assert the database record's path, directory, and creator_id are unchanged
+            $this->assertDatabaseHas('media', [
+                'id' => $media->id,
+                'path' => $originalPath,
+                'directory' => $originalDir,
+                'creator_id' => $user1->id, // Should be original creator_id
+            ]);
+            throw $e; // Re-throw the exception to satisfy expectException
+        }
     }
 }

--- a/tests/Unit/Observers/MediaObserverTest.php
+++ b/tests/Unit/Observers/MediaObserverTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit\Observers;
+
+use App\Models\Media;
+use App\Models\User;
+use Awcodes\Curator\PathGenerators\UserPathGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class MediaObserverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Mock the file system
+        Storage::fake('public');
+        // Set the config to use the UserPathGenerator for this test
+        config(['curator.path_generator' => UserPathGenerator::class]);
+        config(['curator.directory' => 'media']);
+    }
+
+    public function test_moves_the_file_and_updates_db_when_creator_id_is_changed(): void
+    {
+        // 1. Arrange
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        // Create a dummy file in the original user's directory
+        $originalDir = 'media/'.$user1->id;
+        $filename = 'test-image.jpg';
+        $originalPath = $originalDir.'/'.$filename;
+        Storage::disk('public')->put($originalPath, 'dummy content');
+
+        // Create a media record pointing to the original file
+        $media = Media::factory()->create([
+            'creator_id' => $user1->id,
+            'disk' => 'public',
+            'directory' => $originalDir,
+            'path' => $originalPath,
+        ]);
+
+        $newDir = 'media/'.$user2->id;
+        $newPath = $newDir.'/'.$filename;
+
+        // 2. Act
+        // Update the creator_id, which should trigger the observer's 'updated' method
+        $media->creator_id = $user2->id;
+        $media->save();
+
+        // 3. Assert
+        // Assert the original file no longer exists
+        $this->assertFalse(Storage::disk('public')->exists($originalPath));
+        // Assert the new file exists in the new location
+        $this->assertTrue(Storage::disk('public')->exists($newPath));
+
+        // Assert the database record has been updated
+        $this->assertDatabaseHas('media', [
+            'id' => $media->id,
+            'path' => $newPath,
+            'directory' => $newDir,
+            'creator_id' => $user2->id,
+        ]);
+    }
+}


### PR DESCRIPTION
This pull request introduces a robust creator ownership system for media assets, ensuring data integrity and consistent file organization. It mandates a creator for every media item, automates creator assignment, and handles the relocation of media files when ownership changes.

Key features and improvements include:

- **Mandatory Media Creator**:

  - The `creator_id` is now a required field when creating or editing media, ensuring every asset is associated with a user.
  - The system now throws an `AuthenticationException` if an attempt is made to create media without a creator when no user is authenticated.

- **Automatic Creator Assignment**:

  - The `MediaObserver` automatically assigns the currently authenticated user as the creator for new media if one is not explicitly provided. This streamlines the upload process while maintaining data integrity.

- **Automatic File Relocation on Creator Change**:

  - When a media item's `creator_id` is updated, and the `UserPathGenerator` is in use, the associated file is automatically moved on the disk to the new creator's directory.
  - The media record's `path` and `directory` attributes are updated to reflect the new location.

- **Transactional Integrity**:

  - The entire file relocation process—including the file system move and the database update—is now wrapped in a database transaction. This ensures the operation is atomic; if any part fails, the transaction is rolled back, preventing inconsistent states.

- **UI and UX Fixes**:

  - The "preview" action on the media edit page now correctly links to the asset's public URL and opens it in a new tab for a better user experience.

- **Comprehensive Testing**:
  - Extensive feature and unit tests have been added to cover all new logic, including creator validation, automatic assignment, file relocation success/failure cases, and transaction rollbacks.