### PR TITLE
feat: enhance user management and registration experience

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -139,6 +139,16 @@ class UserResource extends Resource
                 Tables\Columns\TextColumn::make('email_verified_at')
                     ->label(__('user.resource.email_verified_at'))
                     ->dateTime(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->label(ucfirst(__('validation.attributes.created_at')))
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->label(ucfirst(__('validation.attributes.updated_at')))
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
             ]))
             ->filters([
                 //

--- a/app/Livewire/Auth/Register.php
+++ b/app/Livewire/Auth/Register.php
@@ -51,6 +51,7 @@ class Register extends Component implements HasForms
                     ->schema(array_filter([
                         TextInput::make('name')
                             ->label(__('filament-panels::pages/auth/register.form.name.label'))
+                            ->default(old('name'))
                             ->required()
                             ->maxLength(255)
                             ->autofocus()
@@ -58,11 +59,12 @@ class Register extends Component implements HasForms
                             ->extraInputAttributes(['name' => 'name']),
                         TextInput::make('email')
                             ->label(__('filament-panels::pages/auth/register.form.email.label'))
+                            ->default(old('email'))
                             ->email()
                             ->required()
                             ->maxLength(255)
                             ->unique(User::class)
-                            ->autocomplete('username')
+                            ->autocomplete('email')
                             ->extraInputAttributes(['name' => 'email']),
                         TextInput::make('password')
                             ->label(__('filament-panels::pages/auth/register.form.password.label'))

--- a/tests/Feature/Filament/Resources/UserResourceTest.php
+++ b/tests/Feature/Filament/Resources/UserResourceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Filament\Resources;
 use App\Filament\Resources\UserResource;
 use App\Filament\Resources\UserResource\Pages\CreateUser;
 use App\Filament\Resources\UserResource\Pages\EditUser;
+use App\Filament\Resources\UserResource\Pages\ListUsers;
 use App\Models\Page;
 use App\Models\Permission;
 use App\Models\Role;
@@ -162,11 +163,25 @@ class UserResourceTest extends TestCase
         $livewire->assertCanRenderTableColumn('email');
         $livewire->assertCanRenderTableColumn('roles');
         $livewire->assertCanRenderTableColumn('email_verified_at');
+        $livewire->assertCanRenderTableColumn('created_at');
+        $livewire->assertCanRenderTableColumn('updated_at');
 
         if (Jetstream::managesProfilePhotos()) {
             Livewire::test(UserResource\Pages\ListUsers::class)
                 ->assertCanRenderTableColumn('profile_photo_media_id');
         }
+    }
+
+    public function test_created_at_and_updated_at_columns_are_hidden_by_default(): void
+    {
+        User::factory()->create();
+
+        /** @var ListUsers */
+        $livewire = Livewire::test(ListUsers::class)->instance();
+        $table = $livewire->getTable();
+
+        $this->assertTrue($table->getColumn('created_at')?->isToggledHidden());
+        $this->assertTrue($table->getColumn('updated_at')?->isToggledHidden());
     }
 
     public function test_super_users_are_not_listed_for_non_super_admin(): void

--- a/tests/Feature/Livewire/Auth/RegisterTest.php
+++ b/tests/Feature/Livewire/Auth/RegisterTest.php
@@ -25,8 +25,10 @@ class RegisterTest extends TestCase
         $testable->assertFormExists();
         $testable->assertFormFieldExists('name');
         $testable->assertSeeHtml('name="name"');
+        $testable->assertSeeHtml('autocomplete="name"');
         $testable->assertFormFieldExists('email');
         $testable->assertSeeHtml('name="email"');
+        $testable->assertSeeHtml('autocomplete="email"');
         $testable->assertFormFieldExists('password');
         $testable->assertSeeHtml('name="password"');
         $testable->assertFormFieldExists('passwordConfirmation');
@@ -73,6 +75,24 @@ class RegisterTest extends TestCase
 
         $this->assertAuthenticated();
         $response->assertRedirect(route('filament.admin.pages.dashboard', absolute: false));
+    }
+
+    public function test_name_and_email_fields_repopulate_on_validation_error(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'not-matching-password',
+            'terms' => \Laravel\Jetstream\Jetstream::hasTermsAndPrivacyPolicyFeature(),
+        ]);
+
+        $response->assertSessionHasErrors(['password']);
+        $response->assertSessionHas('_old_input', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'terms' => \Laravel\Jetstream\Jetstream::hasTermsAndPrivacyPolicyFeature(),
+        ]);
     }
 
     public function test_honeypot_field_is_present(): void


### PR DESCRIPTION
This pull request introduces several enhancements to both the user-facing registration process and the admin-facing user management table.

**Registration Form Usability:**

- The registration form now retains the 'name' and 'email' values when a validation error occurs. This improves user experience by preventing data loss and reducing re-entry.
- The 'email' input field's autocomplete attribute has been corrected from 'username' to 'email' to ensure proper browser autofill suggestions.
- Tests have been added to verify that form data is repopulated on validation failure and that the correct autocomplete attributes are present.

**User Resource Table:**

- Adds `created_at` and `updated_at` timestamp columns to the Filament User resource table, providing administrators with valuable audit information.
- These new columns are sortable and hidden by default to avoid cluttering the main view.
- Corresponding tests have been implemented to ensure the columns are present and default to a hidden state.