### PR TITLE
feat: enhance LLM commands with prompt inspection and editor integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ php artisan llm:pr
 ```
 
 Both `llm:commit` and `llm:pr` commands support the following options:
-- `--editor`: Specify an editor to open the generated message for further editing (e.g., `--editor="nano"`, `--editor="vim"`, `--editor="code --wait"`).
-- `--only-prompt`: Only generate and output the prompt that would be sent to the language model, without actually sending it.
 
+-   `--editor`: Specify an editor to open the generated content for further editing (e.g., `--editor="nano"`, `--editor="vim"`, `--editor="code --wait"`). If not provided, you will be prompted to open the content in an editor.
+-   `--only-prompt`: Prevents sending the request to the LLM. Instead, it generates and displays the prompt that _would_ have been sent, offering to open it in an editor for inspection.
 
 ## Upstream
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ To generate a pull request message based on a commit range:
 php artisan llm:pr
 ```
 
+Both `llm:commit` and `llm:pr` commands support the following options:
+- `--editor`: Specify an editor to open the generated message for further editing (e.g., `--editor="nano"`, `--editor="vim"`, `--editor="code --wait"`).
+- `--only-prompt`: Only generate and output the prompt that would be sent to the language model, without actually sending it.
+
+
 ## Upstream
 
 Apply any changes available from the Laravel [12.x branch](https://github.com/laravel/laravel/compare/d9d449413dd458f031127085f82389ef18aa0079...12.x).

--- a/app/Console/Commands/Llm/Commit.php
+++ b/app/Console/Commands/Llm/Commit.php
@@ -76,6 +76,8 @@ class Commit extends Command
             ':git_diff' => $gitDiff,
         ]);
 
-        return $this->generateLlmResponse($prompt, 'commit message');
+        $this->generateLlmResponse($prompt, 'commit message');
+
+        return self::SUCCESS;
     }
 }

--- a/app/Console/Commands/Llm/Commit.php
+++ b/app/Console/Commands/Llm/Commit.php
@@ -152,11 +152,18 @@ class Commit extends Command
 
                 try {
                     $process->run(); // Execute the editor process
+
+                    if (! $process->isSuccessful()) {
+                        $this->error("The editor process failed. Please check if '{$editor}' is a valid command.");
+                        $this->error($process->getErrorOutput()); // Output the process error for more details
+                    }
                 } catch (\Exception $e) {
                     $this->error('Error during editor execution: '.$e->getMessage());
                 } finally {
                     // Clean up the temporary file
-                    File::delete($tempFilePath);
+                    if (File::exists($tempFilePath)) {
+                        File::delete($tempFilePath);
+                    }
                 }
             } else {
                 $this->warn('No editor command provided. Skipping editor step.');

--- a/app/Console/Commands/Llm/Commit.php
+++ b/app/Console/Commands/Llm/Commit.php
@@ -15,7 +15,7 @@ class Commit extends Command
      *
      * @var string
      */
-    protected $signature = 'llm:commit {--editor= : Specify the editor to use (e.g., nano, vim, code --wait)}';
+    protected $signature = 'llm:commit {--editor= : Specify the editor to use (e.g., nano, vim, code --wait)} {--only-prompt : Only generate and output the prompt without sending it to the agent}';
 
     /**
      * The console command description.
@@ -74,6 +74,15 @@ class Commit extends Command
             ':git_diff' => $gitDiff,
         ]);
 
+        if ($this->option('only-prompt')) {
+            $this->info('Generated Prompt:');
+            $this->line($prompt);
+
+            $this->openInEditor($prompt, 'prompt');
+
+            return;
+        }
+
         /** @var string */
         $usingProvider = config('prism.using.provider');
         /** @var string */
@@ -101,11 +110,19 @@ class Commit extends Command
         $this->info("Prompt tokens: {$response->usage->promptTokens}");
         $this->info("Completion tokens: {$response->usage->completionTokens}");
 
+        $this->openInEditor($proposedMessage, 'commit message');
+    }
+
+    /**
+     * Opens content in a user-specified editor.
+     */
+    protected function openInEditor(string $content, string $type): void
+    {
         /** @var ?string */
         $editor = $this->option('editor');
 
         if (! $editor) {
-            $editInEditor = $this->confirm('Do you want to open this message in an editor to make changes?');
+            $editInEditor = $this->confirm("Do you want to open this {$type} in an editor to make changes?");
         } else {
             $editInEditor = true;
         }
@@ -118,13 +135,13 @@ class Commit extends Command
             }
 
             if ($editor) {
-                // Create a unique temporary file path for the commit message
-                $tempFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'llm_commit_'.Str::uuid()->toString().'.md';
+                // Create a unique temporary file path
+                $tempFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'llm_'.Str::slug($type).'_'.Str::uuid()->toString().'.md';
 
-                // Write the proposed message to the temporary file
-                File::put($tempFilePath, $proposedMessage);
+                // Write the content to the temporary file
+                File::put($tempFilePath, $content);
 
-                $this->info("Opening commit message in editor: '{$editor} {$tempFilePath}'");
+                $this->info("Opening {$type} in editor: '{$editor} {$tempFilePath}'");
 
                 // Construct the process command string, escaping the file path
                 $command = "{$editor} ".escapeshellarg($tempFilePath);

--- a/app/Console/Commands/Llm/Commit.php
+++ b/app/Console/Commands/Llm/Commit.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands\Llm;
 
-use App\Console\Commands\Llm\Concerns\HandlesLlmOutput;
 use App\Console\Commands\Llm\Concerns\InteractsWithPrism;
 use App\Console\Commands\Llm\Concerns\RunsInDevelopment;
 use Illuminate\Console\Command;
@@ -10,7 +9,6 @@ use Symfony\Component\Process\Process;
 
 class Commit extends Command
 {
-    use HandlesLlmOutput;
     use InteractsWithPrism;
     use RunsInDevelopment;
 

--- a/app/Console/Commands/Llm/Commit.php
+++ b/app/Console/Commands/Llm/Commit.php
@@ -2,14 +2,15 @@
 
 namespace App\Console\Commands\Llm;
 
+use App\Console\Commands\Llm\Concerns\HandlesLlmOutput;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Str;
 use Prism\Prism\Prism;
 use Symfony\Component\Process\Process;
 
 class Commit extends Command
 {
+    use HandlesLlmOutput;
+
     /**
      * The name and signature of the console command.
      *
@@ -111,63 +112,5 @@ class Commit extends Command
         $this->info("Completion tokens: {$response->usage->completionTokens}");
 
         $this->openInEditor($proposedMessage, 'commit message');
-    }
-
-    /**
-     * Opens content in a user-specified editor.
-     */
-    protected function openInEditor(string $content, string $type): void
-    {
-        /** @var ?string */
-        $editor = $this->option('editor');
-
-        if (! $editor) {
-            $editInEditor = $this->confirm("Do you want to open this {$type} in an editor to make changes?");
-        } else {
-            $editInEditor = true;
-        }
-
-        if ($editInEditor) {
-            if (! $editor) {
-                // If no editor is found, ask the user
-                /** @var ?string */
-                $editor = $this->ask('Please enter the command for your preferred editor (e.g., nano, vim, code --wait):');
-            }
-
-            if ($editor) {
-                // Create a unique temporary file path
-                $tempFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'llm_'.Str::slug($type).'_'.Str::uuid()->toString().'.md';
-
-                // Write the content to the temporary file
-                File::put($tempFilePath, $content);
-
-                $this->info("Opening {$type} in editor: '{$editor} {$tempFilePath}'");
-
-                // Construct the process command string, escaping the file path
-                $command = "{$editor} ".escapeshellarg($tempFilePath);
-
-                $process = Process::fromShellCommandline($command);
-                $process->setTimeout(null); // Allow indefinite editing time
-                $process->setTty(Process::isTtySupported()); // Enable TTY for interactive editors
-
-                try {
-                    $process->run(); // Execute the editor process
-
-                    if (! $process->isSuccessful()) {
-                        $this->error("The editor process failed. Please check if '{$editor}' is a valid command.");
-                        $this->error($process->getErrorOutput()); // Output the process error for more details
-                    }
-                } catch (\Exception $e) {
-                    $this->error('Error during editor execution: '.$e->getMessage());
-                } finally {
-                    // Clean up the temporary file
-                    if (File::exists($tempFilePath)) {
-                        File::delete($tempFilePath);
-                    }
-                }
-            } else {
-                $this->warn('No editor command provided. Skipping editor step.');
-            }
-        }
     }
 }

--- a/app/Console/Commands/Llm/Concerns/HandlesLlmOutput.php
+++ b/app/Console/Commands/Llm/Concerns/HandlesLlmOutput.php
@@ -42,7 +42,7 @@ trait HandlesLlmOutput
                 // Construct the process command string, escaping the file path
                 $command = "{$editor} ".escapeshellarg($tempFilePath);
 
-                $process = Process::fromShellCommandline($command);
+                $process = $this->makeProcess($command);
                 $process->setTimeout(null); // Allow indefinite editing time
                 $process->setTty(Process::isTtySupported()); // Enable TTY for interactive editors
 
@@ -63,5 +63,14 @@ trait HandlesLlmOutput
                 $this->warn('No editor command provided. Skipping editor step.');
             }
         }
+    }
+
+    /**
+     * Creates a new Process instance.
+     * This method is isolated to allow for easy mocking in tests.
+     */
+    protected function makeProcess(string $command): Process
+    {
+        return Process::fromShellCommandline($command);
     }
 }

--- a/app/Console/Commands/Llm/Concerns/HandlesLlmOutput.php
+++ b/app/Console/Commands/Llm/Concerns/HandlesLlmOutput.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
+/**
+ * @mixin Command
+ */
 trait HandlesLlmOutput
 {
     /**

--- a/app/Console/Commands/Llm/Concerns/HandlesLlmOutput.php
+++ b/app/Console/Commands/Llm/Concerns/HandlesLlmOutput.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Console\Commands\Llm\Concerns;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Symfony\Component\Process\Process;
+
+trait HandlesLlmOutput
+{
+    /**
+     * Opens content in a user-specified editor.
+     */
+    protected function openInEditor(string $content, string $type): void
+    {
+        /** @var ?string */
+        $editor = $this->option('editor');
+
+        if (! $editor) {
+            $editInEditor = $this->confirm("Do you want to open this {$type} in an editor to make changes?");
+        } else {
+            $editInEditor = true;
+        }
+
+        if ($editInEditor) {
+            if (! $editor) {
+                // If no editor is found, ask the user
+                /** @var ?string */
+                $editor = $this->ask('Please enter the command for your preferred editor (e.g., nano, vim, code --wait):');
+            }
+
+            if ($editor) {
+                // Create a unique temporary file path
+                $tempFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'llm_'.Str::slug($type).'_'.Str::uuid()->toString().'.md';
+
+                // Write the content to the temporary file
+                File::put($tempFilePath, $content);
+
+                $this->info("Opening {$type} in editor: '{$editor} {$tempFilePath}'");
+
+                // Construct the process command string, escaping the file path
+                $command = "{$editor} ".escapeshellarg($tempFilePath);
+
+                $process = Process::fromShellCommandline($command);
+                $process->setTimeout(null); // Allow indefinite editing time
+                $process->setTty(Process::isTtySupported()); // Enable TTY for interactive editors
+
+                try {
+                    $process->run(); // Execute the editor process
+
+                    // Add error handling for process execution
+                    if (! $process->isSuccessful()) {
+                        $this->error('Editor process failed: '.$process->getErrorOutput());
+                    }
+                } catch (\Exception $e) {
+                    $this->error('Error during editor execution: '.$e->getMessage());
+                } finally {
+                    // Clean up the temporary file
+                    File::delete($tempFilePath);
+                }
+            } else {
+                $this->warn('No editor command provided. Skipping editor step.');
+            }
+        }
+    }
+}

--- a/app/Console/Commands/Llm/Concerns/InteractsWithPrism.php
+++ b/app/Console/Commands/Llm/Concerns/InteractsWithPrism.php
@@ -2,8 +2,12 @@
 
 namespace App\Console\Commands\Llm\Concerns;
 
+use Illuminate\Console\Command;
 use Prism\Prism\Prism;
 
+/**
+ * @mixin Command
+ */
 trait InteractsWithPrism
 {
     protected function generateLlmResponse(string $prompt, string $messageType): void

--- a/app/Console/Commands/Llm/Concerns/InteractsWithPrism.php
+++ b/app/Console/Commands/Llm/Concerns/InteractsWithPrism.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Console\Commands\Llm\Concerns;
+
+use Prism\Prism\Prism;
+
+trait InteractsWithPrism
+{
+    protected function generateLlmResponse(string $prompt, string $messageType): int
+    {
+        if ($this->option('only-prompt')) {
+            $this->info('Generated Prompt:');
+            $this->line($prompt);
+
+            $this->openInEditor($prompt, 'prompt');
+
+            return self::SUCCESS;
+        }
+
+        /** @var string */
+        $usingProvider = config('prism.using.provider');
+        /** @var string */
+        $usingModel = config('prism.using.model');
+
+        $startTime = microtime(true);
+
+        $response = Prism::text()
+            ->using($usingProvider, $usingModel)
+            ->withPrompt($prompt)
+            ->asText();
+
+        $endTime = microtime(true);
+        $elapsedTime = $endTime - $startTime;
+
+        $proposedMessage = trim($response->text);
+
+        $this->newLine();
+        $this->info("Proposed {$messageType}:");
+        $this->info('------------------------');
+        $this->line($proposedMessage);
+        $this->info('------------------------');
+
+        $this->info('Elapsed time: '.round($elapsedTime, 2).' seconds');
+        $this->info("Prompt tokens: {$response->usage->promptTokens}");
+        $this->info("Completion tokens: {$response->usage->completionTokens}");
+
+        $this->openInEditor($proposedMessage, $messageType);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/Llm/Concerns/InteractsWithPrism.php
+++ b/app/Console/Commands/Llm/Concerns/InteractsWithPrism.php
@@ -10,13 +10,15 @@ use Prism\Prism\Prism;
  */
 trait InteractsWithPrism
 {
+    use HandlesLlmOutput;
+
     protected function generateLlmResponse(string $prompt, string $messageType): void
     {
         if ($this->option('only-prompt')) {
             $this->info('Generated Prompt:');
             $this->line($prompt);
 
-            $this->openInEditor($prompt, 'prompt');
+            $this->output($prompt, 'prompt');
 
             return;
         }
@@ -48,7 +50,6 @@ trait InteractsWithPrism
         $this->info("Prompt tokens: {$response->usage->promptTokens}");
         $this->info("Completion tokens: {$response->usage->completionTokens}");
 
-        $this->openInEditor($proposedMessage, $messageType);
-
+        $this->output($proposedMessage, $messageType);
     }
 }

--- a/app/Console/Commands/Llm/Concerns/InteractsWithPrism.php
+++ b/app/Console/Commands/Llm/Concerns/InteractsWithPrism.php
@@ -6,7 +6,7 @@ use Prism\Prism\Prism;
 
 trait InteractsWithPrism
 {
-    protected function generateLlmResponse(string $prompt, string $messageType): int
+    protected function generateLlmResponse(string $prompt, string $messageType): void
     {
         if ($this->option('only-prompt')) {
             $this->info('Generated Prompt:');
@@ -14,7 +14,7 @@ trait InteractsWithPrism
 
             $this->openInEditor($prompt, 'prompt');
 
-            return self::SUCCESS;
+            return;
         }
 
         /** @var string */
@@ -46,6 +46,5 @@ trait InteractsWithPrism
 
         $this->openInEditor($proposedMessage, $messageType);
 
-        return self::SUCCESS;
     }
 }

--- a/app/Console/Commands/Llm/Concerns/RunsInDevelopment.php
+++ b/app/Console/Commands/Llm/Concerns/RunsInDevelopment.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Console\Commands\Llm\Concerns;
+
+trait RunsInDevelopment
+{
+    protected function ensureDevelopmentEnvironment(): bool
+    {
+        if (app()->environment('production')) {
+            $this->error('This command can only be run in a development environment.');
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Console/Commands/Llm/Concerns/RunsInDevelopment.php
+++ b/app/Console/Commands/Llm/Concerns/RunsInDevelopment.php
@@ -2,6 +2,11 @@
 
 namespace App\Console\Commands\Llm\Concerns;
 
+use Illuminate\Console\Command;
+
+/**
+ * @mixin Command
+ */
 trait RunsInDevelopment
 {
     protected function ensureDevelopmentEnvironment(): bool

--- a/app/Console/Commands/Llm/Pr.php
+++ b/app/Console/Commands/Llm/Pr.php
@@ -83,6 +83,8 @@ class Pr extends Command
             ':commit_messages' => $commitMessages,
         ]);
 
-        return $this->generateLlmResponse($prompt, 'pull request message');
+        $this->generateLlmResponse($prompt, 'pull request message');
+
+        return self::SUCCESS;
     }
 }

--- a/app/Console/Commands/Llm/Pr.php
+++ b/app/Console/Commands/Llm/Pr.php
@@ -40,7 +40,7 @@ class Pr extends Command
         /** @var string */
         $commit_hash_2 = $this->ask('Please enter second commit hash (newer)');
 
-        $process = resolve(Process::class, ['git', 'log', '--format=%B%n---%n', '--reverse', "$commit_hash_1..$commit_hash_2"]);
+        $process = resolve(Process::class, ['command' => ['git', 'log', '--format=%B%n---%n', '--reverse', "$commit_hash_1..$commit_hash_2"]]);
         $process->run();
 
         if (! $process->isSuccessful()) {

--- a/app/Console/Commands/Llm/Pr.php
+++ b/app/Console/Commands/Llm/Pr.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands\Llm;
 
-use App\Console\Commands\Llm\Concerns\HandlesLlmOutput;
 use App\Console\Commands\Llm\Concerns\InteractsWithPrism;
 use App\Console\Commands\Llm\Concerns\RunsInDevelopment;
 use Illuminate\Console\Command;
@@ -10,7 +9,6 @@ use Symfony\Component\Process\Process;
 
 class Pr extends Command
 {
-    use HandlesLlmOutput;
     use InteractsWithPrism;
     use RunsInDevelopment;
 
@@ -42,7 +40,7 @@ class Pr extends Command
         /** @var string */
         $commit_hash_2 = $this->ask('Please enter second commit hash (newer)');
 
-        $process = new Process(['git', 'log', '--format=%B%n---%n', '--reverse', "$commit_hash_1..$commit_hash_2"]);
+        $process = resolve(Process::class, ['git', 'log', '--format=%B%n---%n', '--reverse', "$commit_hash_1..$commit_hash_2"]);
         $process->run();
 
         if (! $process->isSuccessful()) {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "mockery/mockery": "^1.6.12",
         "nunomaduro/collision": "^8.8.2",
         "phpunit/phpunit": "^11.5.33",
-        "prism-php/prism": "^0.59.0"
+        "prism-php/prism": "^0.86.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2805ca706f3c204eeb5e8f82a9cf8bc5",
+    "content-hash": "abb106291d0a5150cc8c83e062d10c5d",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -15248,26 +15248,27 @@
         },
         {
             "name": "prism-php/prism",
-            "version": "v0.59.0",
+            "version": "v0.86.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/prism-php/prism.git",
-                "reference": "356f0ddbe02b9559ca141359377cad4046d7e5f3"
+                "reference": "1b9910fba9946c99323e6ddbe9719c2c4ad7dacb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/prism-php/prism/zipball/356f0ddbe02b9559ca141359377cad4046d7e5f3",
-                "reference": "356f0ddbe02b9559ca141359377cad4046d7e5f3",
+                "url": "https://api.github.com/repos/prism-php/prism/zipball/1b9910fba9946c99323e6ddbe9719c2c4ad7dacb",
+                "reference": "1b9910fba9946c99323e6ddbe9719c2c4ad7dacb",
                 "shasum": ""
             },
             "require": {
+                "ext-fileinfo": "*",
                 "laravel/framework": "^11.0|^12.0",
                 "php": "^8.2"
             },
             "require-dev": {
                 "laravel/pint": "^1.14",
                 "mockery/mockery": "^1.6",
-                "orchestra/testbench": "^9.4",
+                "orchestra/testbench": "^10",
                 "pestphp/pest": "^3.0",
                 "pestphp/pest-plugin-arch": "^3.0",
                 "pestphp/pest-plugin-laravel": "^3.0",
@@ -15292,6 +15293,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
                 "psr-4": {
                     "Prism\\Prism\\": "src/"
                 }
@@ -15309,7 +15313,7 @@
             "description": "A powerful Laravel package for integrating Large Language Models (LLMs) into your applications.",
             "support": {
                 "issues": "https://github.com/prism-php/prism/issues",
-                "source": "https://github.com/prism-php/prism/tree/v0.59.0"
+                "source": "https://github.com/prism-php/prism/tree/v0.86.0"
             },
             "funding": [
                 {
@@ -15317,7 +15321,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-10T18:21:01+00:00"
+            "time": "2025-08-22T07:19:48+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/tests/Feature/Console/Commands/Llm/CommitTest.php
+++ b/tests/Feature/Console/Commands/Llm/CommitTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Console\Commands\Llm;
+namespace Tests\Feature\Console\Commands\Llm;
 
 use App\Console\Commands\Llm\Commit;
 use Illuminate\Console\Command;

--- a/tests/Feature/Console/Commands/Llm/Concerns/HandlesLlmOutputTest.php
+++ b/tests/Feature/Console/Commands/Llm/Concerns/HandlesLlmOutputTest.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace Tests\Unit\Console\Commands\Llm\Concerns;
+
+use App\Console\Commands\Llm\Concerns\HandlesLlmOutput;
+use Illuminate\Console\Command;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Mockery;
+use Mockery\Expectation;
+use Mockery\MockInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+/**
+ * A stub command class that uses the trait we want to test.
+ */
+class TestCommandUsingTrait extends Command
+{
+    use HandlesLlmOutput;
+
+    protected $signature = 'test:command';
+
+    // This public method allows us to call the protected trait method from our test.
+    public function invokeOpenInEditor(string $content, string $type): void
+    {
+        $this->openInEditor($content, $type);
+    }
+}
+
+class HandlesLlmOutputTest extends TestCase
+{
+    private TestCommandUsingTrait|MockInterface $command;
+
+    private MockInterface $processMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // 1. Create the instance mock for the Process object.
+        // This is what our trait's methods will interact with.
+        $this->processMock = Mockery::mock(Process::class);
+
+        // 2. Create a partial mock of our test command.
+        /** @var MockInterface */
+        $command = Mockery::mock(TestCommandUsingTrait::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+
+        $this->command = $command;
+
+        // 3. Set a mock output object on the command to prevent "writeln() on null" errors.
+        /** @var MockInterface */
+        $output = Mockery::mock(OutputStyle::class);
+
+        /** @var Expectation */
+        $expectation = $output->shouldReceive('writeln');
+        $expectation->withAnyArgs()->byDefault(); // Accept any output calls
+
+        /** @var TestCommandUsingTrait */
+        $command = $this->command;
+
+        /** @var OutputStyle $output */
+        $command->setOutput($output);
+
+        // Mock the File facade
+        File::shouldReceive('put')->byDefault();
+        File::shouldReceive('delete')->byDefault();
+
+        // Use Laravel's built-in testing helper to control UUID generation
+        Str::createUuidsUsing(fn () => Uuid::fromString('a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5'));
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Str::createUuidsNormally(); // Reset the UUID factory after the test
+    }
+
+    public function test_opens_editor_when_editor_option_is_provided(): void
+    {
+        $editor = 'vim';
+        $content = 'some code';
+        $type = 'test';
+        $tempFilePath = sys_get_temp_dir().'/llm_test_a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5.md';
+
+        /** @var MockInterface */
+        $command = $this->command;
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('option');
+        $expectation->with('editor')->once()->andReturn($editor);
+        $command->shouldNotReceive('confirm');
+        $command->shouldNotReceive('ask');
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('info');
+        $expectation->once()->with("Opening {$type} in editor: '{$editor} {$tempFilePath}'");
+
+        File::shouldReceive('put')->once()->with($tempFilePath, $content);
+        File::shouldReceive('delete')->once()->with($tempFilePath);
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('makeProcess');
+        $expectation->with("{$editor} ".escapeshellarg($tempFilePath))
+            ->once()
+            ->andReturn($this->processMock);
+
+        /** @var Expectation */
+        $expectation = $this->processMock->shouldReceive('setTimeout');
+        $expectation->with(null)->once();
+
+        /** @var Expectation */
+        $expectation = $this->processMock->shouldReceive('setTty');
+        $expectation->once()->andReturnSelf();
+
+        /** @var Expectation */
+        $expectation = $this->processMock->shouldReceive('run');
+        $expectation->once()->andReturn(0); // Simulate a successful exit
+
+        /** @var Expectation */
+        $expectation = $this->processMock->shouldReceive('isSuccessful');
+        $expectation->once()->andReturn(true);
+
+        /** @var TestCommandUsingTrait */
+        $command = $this->command;
+        $command->invokeOpenInEditor($content, $type);
+    }
+
+    public function test_prompts_for_editor_when_option_is_not_provided_and_user_confirms(): void
+    {
+        $editor = 'nano';
+        $content = 'some other code';
+        $type = 'class';
+        $tempFilePath = sys_get_temp_dir().'/llm_class_a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5.md';
+
+        /** @var MockInterface */
+        $command = $this->command;
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('option');
+        $expectation->with('editor')->once()->andReturn(null);
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('confirm');
+        $expectation->once()->andReturn(true);
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('ask');
+        $expectation->once()->andReturn($editor);
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('info');
+        $expectation->once()->with("Opening {$type} in editor: '{$editor} {$tempFilePath}'");
+
+        File::shouldReceive('put')->once()->with($tempFilePath, $content);
+        File::shouldReceive('delete')->once()->with($tempFilePath);
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('makeProcess');
+        $expectation->with("{$editor} ".escapeshellarg($tempFilePath))
+            ->once()
+            ->andReturn($this->processMock);
+
+        /** @var Expectation */
+        $expectation = $this->processMock->shouldReceive('setTimeout');
+        $expectation->with(null)->once()->andReturnSelf();
+
+        /** @var Expectation */
+        $expectation = $this->processMock->shouldReceive('setTty');
+        $expectation->once()->andReturnSelf();
+
+        /** @var Expectation */
+        $expectation = $this->processMock->shouldReceive('run');
+        $expectation->once();
+
+        /** @var Expectation */
+        $expectation = $this->processMock->shouldReceive('isSuccessful');
+        $expectation->once()->andReturn(true);
+
+        /** @var TestCommandUsingTrait */
+        $command = $this->command;
+        $command->invokeOpenInEditor($content, $type);
+    }
+
+    public function test_does_nothing_if_user_declines_to_open_editor(): void
+    {
+        /** @var MockInterface */
+        $command = $this->command;
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('option');
+        $expectation->with('editor')->once()->andReturn(null);
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('confirm');
+        $expectation->with('Do you want to open this test in an editor to make changes?')
+            ->once()
+            ->andReturn(false);
+
+        $command->shouldNotReceive('ask');
+        $command->shouldNotReceive('info');
+
+        File::shouldNotReceive('put'); // @phpstan-ignore-line
+        File::shouldNotReceive('delete'); // @phpstan-ignore-line
+
+        $this->processMock->shouldNotReceive('makeProcess');
+
+        /** @var TestCommandUsingTrait */
+        $command = $this->command;
+        $command->invokeOpenInEditor('content', 'test');
+    }
+
+    public function test_warns_and_skips_if_user_provides_no_editor_command(): void
+    {
+        /** @var MockInterface */
+        $command = $this->command;
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('option');
+        $expectation->with('editor')->once()->andReturn(null);
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('confirm');
+        $expectation->once()->andReturn(true);
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('ask');
+        $expectation->once()->andReturn(null); // User just presses enter
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('warn');
+        $expectation->once()->with('No editor command provided. Skipping editor step.');
+
+        $command->shouldNotReceive('info');
+
+        File::shouldNotReceive('put'); // @phpstan-ignore-line
+        File::shouldNotReceive('delete'); // @phpstan-ignore-line
+
+        $this->processMock->shouldNotReceive('makeProcess');
+
+        /** @var TestCommandUsingTrait */
+        $command = $this->command;
+        $command->invokeOpenInEditor('content', 'test');
+    }
+
+    public function test_handles_a_failed_editor_process_and_cleans_up_file(): void
+    {
+        /** @var MockInterface */
+        $command = $this->command;
+        /** @var MockInterface */
+        $processMock = $this->processMock;
+
+        $editor = 'code --wait';
+        $errorOutput = 'command not found: code';
+        $tempFilePath = sys_get_temp_dir().'/llm_test_a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5.md';
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('option');
+        $expectation->with('editor')->once()->andReturn($editor);
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('error');
+        $expectation->once()->with('Editor process failed: '.$errorOutput);
+
+        File::shouldReceive('put')->once();
+        File::shouldReceive('delete')->once()->with($tempFilePath); // Crucially, still deletes the file
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('makeProcess');
+        $expectation->with("{$editor} ".escapeshellarg($tempFilePath))
+            ->once()
+            ->andReturn($processMock);
+
+        /** @var Expectation */
+        $expectation = $processMock->shouldReceive('setTimeout');
+        $expectation->with(null)->once();
+
+        /** @var Expectation */
+        $expectation = $processMock->shouldReceive('setTty');
+        $expectation->once()->andReturnSelf();
+
+        /** @var Expectation */
+        $expectation = $processMock->shouldReceive('run');
+        $expectation->once();
+
+        /** @var Expectation */
+        $expectation = $processMock->shouldReceive('isSuccessful');
+        $expectation->once()->andReturn(false);
+
+        /** @var Expectation */
+        $expectation = $processMock->shouldReceive('getErrorOutput');
+        $expectation->once()->andReturn($errorOutput);
+
+        /** @var TestCommandUsingTrait */
+        $command = $this->command;
+        $command->invokeOpenInEditor('content', 'test');
+    }
+
+    public function test_handles_an_exception_during_process_execution_and_cleans_up_file(): void
+    {
+        /** @var MockInterface */
+        $command = $this->command;
+        /** @var MockInterface */
+        $processMock = $this->processMock;
+
+        $editor = 'vim';
+        $exceptionMessage = 'Process could not be started.';
+        $tempFilePath = sys_get_temp_dir().'/llm_test_a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5.md';
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('option');
+        $expectation->with('editor')->once()->andReturn($editor);
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('error');
+        $expectation->once()->with('Error during editor execution: '.$exceptionMessage);
+
+        File::shouldReceive('put')->once();
+        File::shouldReceive('delete')->once()->with($tempFilePath); // Crucially, still deletes the file
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('makeProcess');
+        $expectation->with("{$editor} ".escapeshellarg($tempFilePath))
+            ->once()
+            ->andReturn($processMock);
+
+        /** @var Expectation */
+        $expectation = $processMock->shouldReceive('setTimeout');
+        $expectation->with(null)->once();
+
+        /** @var Expectation */
+        $expectation = $processMock->shouldReceive('setTty');
+        $expectation->once()->andReturnSelf();
+
+        /** @var Expectation */
+        $expectation = $processMock->shouldReceive('run');
+        $expectation->once()->andThrow(new \Exception($exceptionMessage));
+        $processMock->shouldNotReceive('isSuccessful');
+
+        /** @var TestCommandUsingTrait */
+        $command = $this->command;
+        $command->invokeOpenInEditor('content', 'test');
+    }
+}

--- a/tests/Feature/Console/Commands/Llm/Concerns/HandlesLlmOutputTest.php
+++ b/tests/Feature/Console/Commands/Llm/Concerns/HandlesLlmOutputTest.php
@@ -24,9 +24,9 @@ class TestCommandUsingTrait extends Command
     protected $signature = 'test:command';
 
     // This public method allows us to call the protected trait method from our test.
-    public function invokeOpenInEditor(string $content, string $type): void
+    public function invokeOutput(string $content, string $type): void
     {
-        $this->openInEditor($content, $type);
+        $this->output($content, $type);
     }
 }
 
@@ -127,7 +127,7 @@ class HandlesLlmOutputTest extends TestCase
 
         /** @var TestCommandUsingTrait */
         $command = $this->command;
-        $command->invokeOpenInEditor($content, $type);
+        $command->invokeOutput($content, $type);
     }
 
     public function test_prompts_for_editor_when_option_is_not_provided_and_user_confirms(): void
@@ -183,7 +183,7 @@ class HandlesLlmOutputTest extends TestCase
 
         /** @var TestCommandUsingTrait */
         $command = $this->command;
-        $command->invokeOpenInEditor($content, $type);
+        $command->invokeOutput($content, $type);
     }
 
     public function test_does_nothing_if_user_declines_to_open_editor(): void
@@ -211,7 +211,7 @@ class HandlesLlmOutputTest extends TestCase
 
         /** @var TestCommandUsingTrait */
         $command = $this->command;
-        $command->invokeOpenInEditor('content', 'test');
+        $command->invokeOutput('content', 'test');
     }
 
     public function test_warns_and_skips_if_user_provides_no_editor_command(): void
@@ -244,7 +244,7 @@ class HandlesLlmOutputTest extends TestCase
 
         /** @var TestCommandUsingTrait */
         $command = $this->command;
-        $command->invokeOpenInEditor('content', 'test');
+        $command->invokeOutput('content', 'test');
     }
 
     public function test_handles_a_failed_editor_process_and_cleans_up_file(): void
@@ -297,7 +297,7 @@ class HandlesLlmOutputTest extends TestCase
 
         /** @var TestCommandUsingTrait */
         $command = $this->command;
-        $command->invokeOpenInEditor('content', 'test');
+        $command->invokeOutput('content', 'test');
     }
 
     public function test_handles_an_exception_during_process_execution_and_cleans_up_file(): void
@@ -343,6 +343,6 @@ class HandlesLlmOutputTest extends TestCase
 
         /** @var TestCommandUsingTrait */
         $command = $this->command;
-        $command->invokeOpenInEditor('content', 'test');
+        $command->invokeOutput('content', 'test');
     }
 }

--- a/tests/Feature/Console/Commands/Llm/PrTest.php
+++ b/tests/Feature/Console/Commands/Llm/PrTest.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Tests\Feature\Console\Commands\Llm;
+
+use App\Console\Commands\Llm\Pr;
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Testing\WithConsoleEvents;
+use Illuminate\Testing\PendingCommand;
+use Mockery;
+use Mockery\Expectation;
+use Mockery\MockInterface;
+use Prism\Prism\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\ValueObjects\Usage;
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+class PrTest extends TestCase
+{
+    use WithConsoleEvents;
+
+    private string $fakeGitLogOutput;
+
+    private MockInterface $processMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fakeGitLogOutput = "feat: Initial commit\n---\nchore: Add .gitignore\n---\n";
+
+        // Create a single, controllable mock for the Pr class
+        $this->processMock = Mockery::mock(Process::class);
+        $this->app->bind(Process::class, function ($app) {
+            return $this->processMock;
+        });
+
+        // Fake the Prism API to prevent real calls.
+        $fakeResponse = TextResponseFake::make()
+            ->withText('Hello from Prism')
+            ->withUsage(new Usage(10, 20));
+        Prism::fake([$fakeResponse]);
+
+        config([
+            'prism.using.provider' => 'openai',
+            'prism.using.model' => 'gpt-4',
+        ]);
+    }
+
+    protected function mockSuccessfulGitLog(): void
+    {
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('run');
+        $expectation->once();
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('isSuccessful');
+        $expectation->once()->andReturn(true);
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('getOutput');
+        $expectation->once()->andReturn($this->fakeGitLogOutput);
+    }
+
+    public function test_aborts_in_production_environment(): void
+    {
+        $this->app->detectEnvironment(fn () => 'production');
+
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:pr');
+        $command->expectsOutput('This command can only be run in a development environment.')
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    public function test_aborts_if_git_log_fails(): void
+    {
+        // Arrange: Create a mock of the Process class to simulate failure
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('run');
+        $expectation->once();
+
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('isSuccessful');
+        $expectation->once()->andReturn(false);
+
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('getErrorOutput');
+        $expectation->once()->andReturn('fatal: not a git repository');
+
+        // Act & Assert
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:pr');
+        $command->expectsQuestion('Please enter first commit hash (older)', 'abc')
+            ->expectsQuestion('Please enter second commit hash (newer)', 'def')
+            ->expectsOutputToContain('Failed to get commit messages: fatal: not a git repository')
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    public function test_exits_with_a_warning_if_there_are_no_commit_messages(): void
+    {
+        // Arrange: Git log returns an empty string
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('run');
+        $expectation->once();
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('isSuccessful');
+        $expectation->once()->andReturn(true);
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('getOutput');
+        $expectation->once()->andReturn('');
+
+        // Act & Assert
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:pr');
+        $command->expectsQuestion('Please enter first commit hash (older)', 'abc')
+            ->expectsQuestion('Please enter second commit hash (newer)', 'def')
+            ->expectsOutputToContain('No commit messages')
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    public function test_only_generates_and_outputs_the_prompt_with_only_prompt_option(): void
+    {
+        // Arrange: Git log returns fake git log output
+        $this->mockSuccessfulGitLog();
+
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:pr --only-prompt');
+        $command->expectsQuestion('Please enter first commit hash (older)', 'abc')
+            ->expectsQuestion('Please enter second commit hash (newer)', 'def')
+            ->expectsOutput('Generated Prompt:')
+            ->expectsQuestion('Do you want to open this prompt in an editor to make changes?', false)
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_calls_api_and_proposes_pull_request_message(): void
+    {
+        // Arrange: Git log returns fake git log output
+        $this->mockSuccessfulGitLog();
+
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:pr');
+        $command->expectsQuestion('Please enter first commit hash (older)', 'abc')
+            ->expectsQuestion('Please enter second commit hash (newer)', 'def')
+            ->expectsOutput('Proposed pull request message:')
+            ->expectsOutput('Hello from Prism')
+            ->expectsQuestion('Do you want to open this pull request message in an editor to make changes?', false)
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_editor_interaction_flow_with_only_prompt_and_user_confirms(): void
+    {
+        // Arrange: Git log returns fake git log output
+        $this->mockSuccessfulGitLog();
+
+        // Create a partial mock of the command to spy on the protected method
+        $prMock = $this->mock(Pr::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        /** @var Expectation $expectation */
+        $expectation = $prMock->shouldReceive('openInEditor');
+        $expectation->once();
+        /** @var Pr $prMock */
+        $prMock->__construct();
+
+        // Act & Assert
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:pr --only-prompt');
+        $command->expectsQuestion('Please enter first commit hash (older)', 'abc')
+            ->expectsQuestion('Please enter second commit hash (newer)', 'def')
+            ->expectsConfirmation('Do you want to open this prompt in an editor to make changes?', 'yes')
+            ->expectsQuestion('Please enter the command for your preferred editor (e.g., nano, vim, code --wait):', 'vim')
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_editor_interaction_flow_with_only_prompt_and_editor_option(): void
+    {
+        // Arrange: Git log returns fake git log output
+        $this->mockSuccessfulGitLog();
+
+        // Arrange: Mock the Pr command to assert openInEditor is called
+        $prMock = $this->mock(Pr::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        /** @var Expectation $expectation */
+        $expectation = $prMock->shouldReceive('openInEditor');
+        $expectation->once();
+        /** @var Pr $prMock */
+        $prMock->__construct();
+
+        // Act & Assert
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:pr --only-prompt --editor=vim');
+        $command->expectsQuestion('Please enter first commit hash (older)', 'abc')
+            ->expectsQuestion('Please enter second commit hash (newer)', 'def')
+            ->doesntExpectOutput('Do you want to open this prompt in an editor to make changes?')
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_standard_flow_opens_editor_on_user_confirmation(): void
+    {
+        $this->mockSuccessfulGitLog();
+
+        // Arrange: Mock the Pr command to assert openInEditor is called
+        $prMock = $this->mock(Pr::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        /** @var Expectation $expectation */
+        $expectation = $prMock->shouldReceive('openInEditor');
+        $expectation->once();
+        /** @var Pr $prMock */
+        $prMock->__construct();
+
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:pr');
+        $command->expectsQuestion('Please enter first commit hash (older)', 'abc')
+            ->expectsQuestion('Please enter second commit hash (newer)', 'def')
+            ->expectsConfirmation('Do you want to open this pull request message in an editor to make changes?', 'yes')
+            ->expectsQuestion('Please enter the command for your preferred editor (e.g., nano, vim, code --wait):', 'vim')
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_standard_flow_does_not_open_editor_if_user_declines(): void
+    {
+        $this->mockSuccessfulGitLog();
+
+        // Arrange: Mock the Pr command to assert openInEditor is called
+        $prMock = $this->mock(Pr::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $prMock->shouldNotReceive('openInEditor');
+        /** @var Pr $prMock */
+        $prMock->__construct();
+
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:pr');
+        $command->expectsQuestion('Please enter first commit hash (older)', 'abc')
+            ->expectsQuestion('Please enter second commit hash (newer)', 'def')
+            ->expectsConfirmation('Do you want to open this pull request message in an editor to make changes?', 'no')
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_standard_flow_with_editor_flag_opens_editor_directly(): void
+    {
+        $this->mockSuccessfulGitLog();
+
+        // Arrange: Mock the Pr command to assert openInEditor is called
+        $prMock = $this->mock(Pr::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        /** @var Expectation $expectation */
+        $expectation = $prMock->shouldReceive('openInEditor');
+        $expectation->once();
+        /** @var Pr $prMock */
+        $prMock->__construct();
+
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:pr', ['--editor' => 'code --wait']);
+        $command->expectsQuestion('Please enter first commit hash (older)', 'abc')
+            ->expectsQuestion('Please enter second commit hash (newer)', 'def')
+            ->doesntExpectOutput('Do you want to open this pull request message in an editor to make changes?')
+            ->assertSuccessful();
+    }
+}

--- a/tests/Unit/Console/Commands/Llm/CommitTest.php
+++ b/tests/Unit/Console/Commands/Llm/CommitTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Unit\Console\Commands\Llm;
+
+use App\Console\Commands\Llm\Commit;
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Testing\WithConsoleEvents;
+use Illuminate\Testing\PendingCommand;
+use Mockery;
+use Mockery\Expectation;
+use Mockery\MockInterface;
+use Prism\Prism\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\ValueObjects\Usage;
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+class CommitTest extends TestCase
+{
+    use WithConsoleEvents;
+
+    private string $fakeGitDiff;
+
+    private MockInterface $processMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fakeGitDiff = 'diff --git a/file.php b/file.php';
+
+        // Create a single, controllable mock for the Commit class
+        $this->processMock = Mockery::mock(Process::class);
+        $this->app->bind(Process::class, function ($app) {
+            return $this->processMock;
+        });
+
+        // Fake the Prism API to prevent real calls.
+        $fakeResponse = TextResponseFake::make()
+            ->withText('Hello from Prism')
+            ->withUsage(new Usage(10, 20));
+        Prism::fake([$fakeResponse]);
+
+        config([
+            'prism.using.provider' => 'openai',
+            'prism.using.model' => 'gpt-4',
+        ]);
+    }
+
+    public function test_aborts_in_production_environment(): void
+    {
+        $this->app->detectEnvironment(fn () => 'production');
+
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:commit');
+        $command->expectsOutput('This command can only be run in a development environment.')
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    public function test_aborts_if_git_diff_fails(): void
+    {
+        // Arrange: Create a mock of the Process class to simulate failure
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('run');
+        $expectation->once();
+
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('isSuccessful');
+        $expectation->once()->andReturn(false);
+
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('getErrorOutput');
+        $expectation->once()->andReturn('fatal: not a git repository');
+
+        // Act & Assert
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:commit');
+        $command->expectsOutputToContain('Failed to get git diff: fatal: not a git repository')
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    public function test_exits_with_a_warning_if_there_are_no_staged_files(): void
+    {
+        // Arrange: Git diff returns an empty string
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('run');
+        $expectation->once();
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('isSuccessful');
+        $expectation->once()->andReturn(true);
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('getOutput');
+        $expectation->once()->andReturn('');
+
+        // Act & Assert
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:commit');
+        $command->expectsOutputToContain('No staged changes to commit')
+            ->assertExitCode(Command::FAILURE);
+    }
+
+    public function test_only_generates_and_outputs_the_prompt_with_only_prompt_option(): void
+    {
+        // Arrange: Git diff returns fake git diff
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('run');
+        $expectation->once();
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('isSuccessful');
+        $expectation->once()->andReturn(true);
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('getOutput');
+        $expectation->once()->andReturn($this->fakeGitDiff);
+
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:commit --only-prompt');
+        $command->expectsOutput('Generated Prompt:')
+            ->expectsQuestion('Do you want to open this prompt in an editor to make changes?', false)
+            ->assertExitCode(Command::SUCCESS);
+    }
+
+    public function test_calls_api_and_proposes_commit_message(): void
+    {
+        // Arrange: Git diff returns fake git diff
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('run');
+        $expectation->once();
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('isSuccessful');
+        $expectation->once()->andReturn(true);
+        /** @var Expectation $expectation */
+        $expectation = $this->processMock->shouldReceive('getOutput');
+        $expectation->once()->andReturn($this->fakeGitDiff);
+
+        /** @var PendingCommand */
+        $command = $this->artisan('llm:commit');
+        $command->expectsOutput('Proposed commit message:')
+            ->expectsOutput('Hello from Prism')
+            ->expectsQuestion('Do you want to open this commit message in an editor to make changes?', false)
+            ->assertExitCode(Command::SUCCESS);
+    }
+}

--- a/tests/Unit/Console/Commands/Llm/Concerns/InteractsWithPrismTest.php
+++ b/tests/Unit/Console/Commands/Llm/Concerns/InteractsWithPrismTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Tests\Unit\Console\Commands\Llm\Concerns;
+
+use App\Console\Commands\Llm\Concerns\HandlesLlmOutput;
+use App\Console\Commands\Llm\Concerns\InteractsWithPrism;
+use Illuminate\Console\Command;
+use Mockery;
+use Mockery\Expectation;
+use Mockery\MockInterface;
+use Prism\Prism\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\Text\Request;
+use Prism\Prism\ValueObjects\Usage;
+use Tests\TestCase;
+
+/**
+ * A concrete command class for testing the trait's behavior.
+ */
+class TestCommandForPrism extends Command
+{
+    use HandlesLlmOutput, InteractsWithPrism;
+
+    protected $signature = 'test:prism-command';
+
+    // The `output` method comes from `HandlesLlmOutput`.
+    // We will mock it to verify it's called correctly.
+    public function output(string $content, string $type): void
+    {
+        // Stub implementation for the test class.
+    }
+
+    // The `output` method comes from `HandlesLlmOutput`.
+    // We will mock it to verify it's called correctly.
+    public function invokeGenerateLlmResponse(string $prompt, string $messageType): void
+    {
+        $this->generateLlmResponse($prompt, $messageType);
+    }
+}
+
+class InteractsWithPrismTest extends TestCase
+{
+    private MockInterface|TestCommandForPrism $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a partial mock of our test command to mock console methods.
+        /** @var MockInterface */
+        $command = Mockery::mock(TestCommandForPrism::class)->makePartial();
+        $this->command = $command;
+        $this->command->shouldAllowMockingProtectedMethods();
+    }
+
+    /**
+     * @covers \App\Console\Commands\Llm\Concerns\InteractsWithPrism::generateLlmResponse
+     */
+    public function test_displays_prompt_and_outputs_it_when_only_prompt_option_is_used(): void
+    {
+        // 1. Arrange
+        $prompt = 'This is the test prompt to be displayed.';
+        $messageType = 'Commit Message';
+
+        // Set up the fake implementation. We expect no API calls.
+        $fake = Prism::fake();
+
+        /** @var MockInterface */
+        $command = $this->command;
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('option');
+        $expectation->with('only-prompt')->once()->andReturn(true);
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('info');
+        $expectation->with('Generated Prompt:')->once();
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('line');
+        $expectation->with($prompt)->once();
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('output');
+        $expectation->with($prompt, 'prompt')->once();
+
+        // 2. Act
+        /** @var TestCommandForPrism $command */
+        $command->invokeGenerateLlmResponse($prompt, $messageType);
+
+        // 3. Assert
+        // Verify that no API call was made to Prism.
+        $fake->assertCallCount(0);
+    }
+
+    /**
+     * @covers \App\Console\Commands\Llm\Concerns\InteractsWithPrism::generateLlmResponse
+     */
+    public function test_calls_prism_with_the_correct_prompt_and_configuration(): void
+    {
+        // 1. Arrange
+        $prompt = 'Generate a commit message for these changes.';
+        $messageType = 'Commit Message';
+        $provider = 'openai';
+        $model = 'gpt-4-turbo';
+
+        config()->set('prism.using.provider', $provider);
+        config()->set('prism.using.model', $model);
+
+        // Prepare a fake response for Prism to return.
+        $fakeResponse = TextResponseFake::make()
+            ->withText('Test response')
+            ->withUsage(new Usage(10, 20));
+
+        $fake = Prism::fake([$fakeResponse]);
+
+        /** @var MockInterface */
+        $command = $this->command;
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('option');
+        $expectation->with('only-prompt')->andReturn(false);
+
+        // Suppress actual console output for this test.
+        $command->shouldReceive('newLine', 'info', 'line', 'output');
+
+        // 2. Act
+        /** @var TestCommandForPrism $command */
+        $command->invokeGenerateLlmResponse($prompt, $messageType);
+
+        // 3. Assert
+        // Verify that a text completion request was sent.
+        $fake->assertRequest(function ($requests) use ($prompt, $provider, $model) {
+            /** @var array<Request> $requests */
+            $this->assertSame($prompt, $requests[0]->prompt());
+            $this->assertSame($provider, $requests[0]->provider());
+            $this->assertSame($model, $requests[0]->model());
+        });
+    }
+
+    /**
+     * @covers \App\Console\Commands\Llm\Concerns\InteractsWithPrism::generateLlmResponse
+     */
+    public function test_formats_and_displays_the_llm_response_and_stats_correctly(): void
+    {
+        // 1. Arrange
+        $messageType = 'Test Output';
+        $llmResponseText = 'This is the generated text from the LLM. '; // Trailing space for trim test
+        $promptTokens = 50;
+        $completionTokens = 150;
+
+        // Prepare the fake response with specific usage data.
+        $fakeResponse = TextResponseFake::make()
+            ->withText($llmResponseText)
+            ->withUsage(new Usage($promptTokens, $completionTokens));
+
+        Prism::fake([$fakeResponse]);
+
+        /** @var MockInterface */
+        $command = $this->command;
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('option');
+        $expectation->with('only-prompt')->andReturn(false);
+
+        // Capture console output to verify formatting.
+        $outputs = [];
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('newLine');
+        $expectation->once()->andReturnUsing(function () use (&$outputs) {
+            $outputs[] = 'NEWLINE';
+        });
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('info');
+        $expectation->andReturnUsing(function (string $msg) use (&$outputs) {
+            $outputs[] = "INFO: {$msg}";
+        });
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('line');
+        $expectation->andReturnUsing(function (string $msg) use (&$outputs) {
+            $outputs[] = "LINE: {$msg}";
+        });
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('output'); // Ignore for this test
+
+        // 2. Act
+        /** @var TestCommandForPrism $command */
+        $command->invokeGenerateLlmResponse('some prompt', $messageType);
+
+        // 3. Assert
+        $this->assertContains('NEWLINE', $outputs);
+        $this->assertContains("INFO: Proposed {$messageType}:", $outputs);
+        $this->assertContains('INFO: ------------------------', $outputs);
+        $this->assertContains('LINE: '.trim($llmResponseText), $outputs); // Check if text is trimmed
+        $this->assertContains("INFO: Prompt tokens: {$promptTokens}", $outputs);
+        $this->assertContains("INFO: Completion tokens: {$completionTokens}", $outputs);
+        $this->assertTrue(
+            (bool) preg_grep('/^INFO: Elapsed time: \d+(\.\d{1,2})? seconds$/', $outputs),
+        );
+    }
+
+    /**
+     * @covers \App\Console\Commands\Llm\Concerns\InteractsWithPrism::generateLlmResponse
+     */
+    public function test_calls_the_output_method_with_the_trimmed_llm_response(): void
+    {
+        // 1. Arrange
+        $messageType = 'Final Message';
+        $llmResponseText = "  Here is the final message. \n"; // With extra whitespace
+        $trimmedResponse = trim($llmResponseText);
+
+        $fakeResponse = TextResponseFake::make()->withText($llmResponseText);
+        Prism::fake([$fakeResponse]);
+
+        /** @var MockInterface */
+        $command = $this->command;
+
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('option');
+        $expectation->with('only-prompt')->andReturn(false);
+
+        // Mute other console output methods.
+        $command->shouldReceive('newLine', 'info', 'line');
+
+        // This is the primary assertion for this test.
+        /** @var Expectation $expectation */
+        $expectation = $command->shouldReceive('output');
+        $expectation->with($trimmedResponse, $messageType)->once();
+
+        // 2. Act
+        /** @var TestCommandForPrism $command */
+        $command->invokeGenerateLlmResponse('some prompt', $messageType);
+
+        // 3. Assert (Handled by Mockery's expectation)
+    }
+}

--- a/tests/Unit/Console/Commands/Llm/Concerns/RunsInDevelopmentTest.php
+++ b/tests/Unit/Console/Commands/Llm/Concerns/RunsInDevelopmentTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Unit\Console\Commands\Llm\Concerns;
+
+use App\Console\Commands\Llm\Concerns\RunsInDevelopment;
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Testing\TestCase;
+use Mockery;
+use Mockery\Expectation;
+use Mockery\MockInterface;
+
+// Define a dummy command for testing the trait
+class TestableCommand extends Command
+{
+    use RunsInDevelopment;
+
+    protected $name = 'test:command';
+
+    protected $description = 'Test command for RunsInDevelopment trait.';
+
+    // Expose the protected method for testing
+    public function callEnsureDevelopmentEnvironment(): bool
+    {
+        return $this->ensureDevelopmentEnvironment();
+    }
+}
+
+class RunsInDevelopmentTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Clean up Mockery expectations after each test
+        Mockery::close();
+    }
+
+    public function test_returns_false_and_shows_error_in_production_environment(): void
+    {
+        // Set the application environment to 'production' for this test
+        $this->app->detectEnvironment(fn () => 'production');
+
+        // Create a mock of the TestableCommand to assert the error method call
+        /** @var MockInterface */
+        $command = Mockery::mock(TestableCommand::class)->makePartial();
+
+        /** @var Expectation */
+        $expectation = $command->shouldReceive('error');
+        $expectation->once()
+            ->with('This command can only be run in a development environment.');
+
+        // Call the method from the trait
+        /** @var TestableCommand $command */
+        $result = $command->callEnsureDevelopmentEnvironment();
+
+        // Assert the return value
+        $this->assertFalse($result);
+    }
+
+    public function test_returns_true_and_shows_no_error_in_non_production_environment(): void
+    {
+        // Set the application environment to 'local' (or any non-production environment) for this test
+        $this->app->detectEnvironment(fn () => 'local');
+
+        // Create a mock of the TestableCommand to ensure the error method is not called
+        $command = Mockery::mock(TestableCommand::class)->makePartial();
+        $command->shouldNotReceive('error');
+
+        // Call the method from the trait
+        /** @var TestableCommand $command */
+        $result = $command->callEnsureDevelopmentEnvironment();
+
+        // Assert the return value
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the `llm:commit` and `llm:pr` commands, focusing on user control, code reusability, and testability.

### Key Features

- **Prompt Inspection (`--only-prompt`)**: Both commands now support a `--only-prompt` flag. This allows users to generate and review the full prompt that will be sent to the LLM without incurring API costs. The prompt can be opened in an editor for inspection or modification.
- **Editor Integration (`--editor`)**: A new `--editor` option allows users to specify an editor to automatically open the generated LLM prompt or message for review and modification.

### Refactoring and Code Quality

- **Shared Logic Extraction**: Common logic has been refactored into reusable traits:
  - `HandlesLlmOutput`: Centralizes the logic for displaying output and opening content in an external editor.
  - `InteractsWithPrism`: Encapsulates all interactions with the Prism LLM service.
  - `RunsInDevelopment`: Provides a consistent check to ensure commands do not run in a production environment.
- **Improved Error Handling**: The editor opening process now includes robust error handling and better diagnostics if the editor command fails. Temporary file cleanup has also been made more resilient.
- **Code Clarity**: PHPDoc annotations (`@mixin`) were added to traits to improve IDE support and static analysis.

### Testing

- **Comprehensive Test Coverage**: Extensive feature and unit tests have been added for the new traits (`HandlesLlmOutput`, `InteractsWithPrism`, `RunsInDevelopment`) and the `llm:commit` and `llm:pr` commands.
- **Test Scenarios**: The new tests cover various use cases, including environment checks, git process failures, editor interactions (prompting and direct opening), API calls, and the `--only-prompt` functionality.

### Documentation

- The `README.md` has been updated to document the new `--only-prompt` and `--editor` options with clear descriptions.