### PR TITLE
feat: add conditional email verification with Fortify middleware

### DIFF
--- a/app/Http/Middleware/EnsureEmailIsVerifiedWithFortify.php
+++ b/app/Http/Middleware/EnsureEmailIsVerifiedWithFortify.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Features as FortifyFeatures;
+
+class EnsureEmailIsVerifiedWithFortify extends EnsureEmailIsVerified
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string|null  $redirectToRoute
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse|null
+     */
+    public function handle($request, Closure $next, $redirectToRoute = null)
+    {
+        // If user is guest or Fortify's email verification feature is not enabled,
+        // simply pass the request to the next middleware without
+        // enforcing email verification.
+        if (! Auth::check() || ! FortifyFeatures::enabled(FortifyFeatures::emailVerification())) {
+            /** @var \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse|null */
+            $response = $next($request);
+
+            return $response;
+        }
+
+        // Otherwise, then call the parent's handle method which
+        // contains the original email verification logic.
+        return parent::handle($request, $next, $redirectToRoute);
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\PageResource;
 use App\Filament\Resources\PermissionResource;
 use App\Filament\Resources\RoleResource;
 use App\Filament\Resources\UserResource;
+use App\Http\Middleware\EnsureEmailIsVerifiedWithFortify;
 use App\Http\Middleware\SetLocaleFromQueryAndSession;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -22,7 +23,6 @@ use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\View\PanelsRenderHook;
 use Filament\Widgets;
-use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
@@ -32,7 +32,6 @@ use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\View\ComponentAttributeBag;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
-use Laravel\Fortify\Features as FortifyFeatures;
 use Laravel\Jetstream\Features;
 
 class AdminPanelProvider extends PanelProvider
@@ -74,10 +73,10 @@ class AdminPanelProvider extends PanelProvider
                 DispatchServingFilamentEvent::class,
                 SetLocaleFromQueryAndSession::class,
             ])
-            ->authMiddleware(array_filter([
-                FortifyFeatures::enabled(FortifyFeatures::emailVerification()) ? EnsureEmailIsVerified::class : null,
+            ->authMiddleware([
+                EnsureEmailIsVerifiedWithFortify::class,
                 Authenticate::class,
-            ]))
+            ])
             ->navigationGroups([
                 NavigationGroup::make()
                     ->label(fn () => __('Administration')),

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -32,7 +32,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'json' => EnsureJsonRequest::class,
             'verify.api.artisan' => VerifyApiArtisan::class,
             'verify.api.key' => VerifyApiKey::class,
-            'verified.fortify' => EnsureEmailIsVerifiedWithFortify::class,
+            'verified' => EnsureEmailIsVerifiedWithFortify::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureEmailIsVerifiedWithFortify;
 use App\Http\Middleware\EnsureJsonRequest;
 use App\Http\Middleware\SetDeviceFromHeader;
 use App\Http\Middleware\SetLocaleFromHeader;
@@ -22,13 +23,16 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->append(ProtectAgainstSpam::class);
         $middleware->append(SetDeviceFromHeader::class);
         $middleware->append(SetLocaleFromHeader::class);
-        $middleware->web(append: [SetLocaleFromQueryAndSession::class]);
+        $middleware->web(append: [
+            SetLocaleFromQueryAndSession::class,
+        ]);
         $middleware->statefulApi();
 
         $middleware->alias([
             'json' => EnsureJsonRequest::class,
             'verify.api.artisan' => VerifyApiArtisan::class,
             'verify.api.key' => VerifyApiKey::class,
+            'verified.fortify' => EnsureEmailIsVerifiedWithFortify::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,11 +6,13 @@ use App\Models\Page;
 use Illuminate\Support\Facades\Route;
 use Laravel\Jetstream\Jetstream;
 
-Route::get('/', function () {
-    return view('welcome');
-})->name('home');
+Route::group(['middleware' => ['verified.fortify']], function () {
+    Route::get('/', function () {
+        return view('welcome');
+    })->name('home');
 
-require __DIR__.'/resources/page.php';
+    require __DIR__.'/resources/page.php';
+});
 
 Route::group(['middleware' => ['auth:sanctum', 'json']], function () {
     require __DIR__.'/resources/user.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,7 @@ use App\Models\Page;
 use Illuminate\Support\Facades\Route;
 use Laravel\Jetstream\Jetstream;
 
-Route::group(['middleware' => ['verified.fortify']], function () {
+Route::group(['middleware' => ['verified']], function () {
     Route::get('/', function () {
         return view('welcome');
     })->name('home');

--- a/tests/Feature/Filament/AdminPanelTest.php
+++ b/tests/Feature/Filament/AdminPanelTest.php
@@ -44,4 +44,20 @@ class AdminPanelTest extends TestCase
 
         $response->assertRedirect('/email/verify'); // Unverified user should be redirected to email verification page
     }
+
+    public function test_verified_user_can_access_admin_panel(): void
+    {
+        $user = User::factory()->create(); // Verified by default
+
+        $response = $this->actingAs($user)->get('/admin');
+
+        $response->assertOk();
+    }
+
+    public function test_guest_user_is_redirected_to_login_page(): void
+    {
+        $response = $this->get('/admin');
+
+        $response->assertRedirect('/login');
+    }
 }

--- a/tests/Feature/Http/Middleware/EnsureEmailIsVerifiedWithFortifyTest.php
+++ b/tests/Feature/Http/Middleware/EnsureEmailIsVerifiedWithFortifyTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\Http\Middleware;
+
+use App\Http\Middleware\EnsureEmailIsVerifiedWithFortify;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Laravel\Fortify\Features;
+use Mockery;
+use Tests\TestCase;
+
+class EnsureEmailIsVerifiedWithFortifyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Ensure FortifyFeatures is not mocked globally by other tests
+        Mockery::close();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_guest_users_are_not_affected_by_the_middleware(): void
+    {
+        Route::get('/test-route', function () {
+            return response('OK', 200);
+        })->middleware(EnsureEmailIsVerifiedWithFortify::class);
+
+        $response = $this->get('/test-route');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('OK', $response->getContent());
+    }
+
+    public function test_unverified_user_is_allowed_to_proceed_when_fortify_feature_is_disabled(): void
+    {
+        // Temporarily disable Fortify's email verification feature for this test
+        config(['fortify.features' => []]);
+
+        // Create an unverified user
+        $user = User::factory()->create(['email_verified_at' => null]);
+
+        $this->actingAs($user);
+
+        Route::get('/test-route', function () {
+            return response('OK', 200);
+        })->middleware(EnsureEmailIsVerifiedWithFortify::class);
+
+        $response = $this->get('/test-route');
+        $response->assertStatus(200);
+        $response->assertSee('OK');
+    }
+
+    public function test_verified_user_is_allowed_to_proceed(): void
+    {
+        // Ensure Fortify's email verification feature is enabled for this test
+        config(['fortify.features' => [Features::emailVerification()]]);
+
+        // Create a verified user
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($user);
+
+        Route::get('/test-route', function () {
+            return response('OK', 200);
+        })->middleware(
+            EnsureEmailIsVerifiedWithFortify::class);
+
+        $response = $this->get('/test-route');
+        $response->assertStatus(200);
+        $response->assertSee('OK');
+    }
+
+    public function test_unverified_user_is_redirected_to_email_verification_prompt_when_feature_is_enabled(): void
+    {
+        // Ensure Fortify's email verification feature is enabled for this test
+        config(['fortify.features' => [Features::emailVerification()]]);
+
+        // Create an unverified user
+        $user = User::factory()->create(['email_verified_at' => null]);
+
+        $this->actingAs($user);
+
+        Route::get('/test-route', function () {
+            return response('Should not reach here', 200);
+        })->middleware(EnsureEmailIsVerifiedWithFortify::class);
+
+        $response = $this->get('/test-route');
+        $response->assertStatus(302);
+        /** @var string */
+        $location = $response->headers->get('Location');
+        $this->assertStringContainsString(route('verification.notice', absolute: false), $location);
+    }
+}

--- a/tests/Feature/WebRoutesTest.php
+++ b/tests/Feature/WebRoutesTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Page\Status;
+use App\Models\Page;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class WebRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_can_access_home_page(): void
+    {
+        $this->get('/')
+            ->assertOk()
+            ->assertViewIs('welcome');
+    }
+
+    public function test_unverified_user_cannot_access_home_page(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => null,
+        ]);
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertRedirect('/email/verify');
+    }
+
+    public function test_verified_user_can_access_home_page(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => Carbon::now(),
+        ]);
+
+        $this->actingAs($user)
+            ->get('/')
+            ->assertOk()
+            ->assertViewIs('welcome');
+    }
+
+    public function test_guest_can_access_a_page_php_route(): void
+    {
+        $page = Page::factory()->create(['status' => Status::Publish]);
+        $this->get(route('pages.show', $page))
+            ->assertOk();
+    }
+
+    public function test_unverified_user_cannot_access_a_page_php_route(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => null,
+        ]);
+
+        $page = Page::factory()->create(['status' => Status::Publish]);
+
+        $this->actingAs($user)
+            ->get(route('pages.show', $page))
+            ->assertRedirect('/email/verify');
+    }
+
+    public function test_verified_user_can_access_a_page_php_route(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => Carbon::now(),
+        ]);
+
+        $page = Page::factory()->create(['status' => Status::Publish]);
+
+        $this->actingAs($user)
+            ->get(route('pages.show', $page))
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
This pull request introduces a custom middleware, `EnsureEmailIsVerifiedWithFortify`, to handle email verification more flexibly within the application, especially in conjunction with Laravel Fortify.

The key changes include:

- A new middleware that extends the default `EnsureEmailIsVerified` but bypasses the check for guest users or when Fortify's email verification feature is disabled.
- Integration of this middleware into the `AdminPanelProvider` and the main `web.php` routes, ensuring consistent verification logic across the admin panel and the frontend.
- Registration of a simplified `verified` alias for the new middleware.
- Comprehensive feature tests have been added to validate the middleware's behavior for guest, verified, and unverified users under different Fortify configurations. Additional tests also cover access control for the main web routes and the admin panel, ensuring overall application integrity.